### PR TITLE
chore(ci): ignore eslint major bumps until plugin ecosystem catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,18 @@ updates:
       - "frontend"
     commit-message:
       prefix: "chore(deps)"
+    # ESLint 10 is blocked upstream: eslint-plugin-react-hooks@7
+    # does not yet accept eslint@^10.0.0. Dependabot keeps reopening
+    # the same unmergeable bump every week, so we ignore the major
+    # version until the plugin ecosystem catches up.
+    # TODO: remove this ignore block once eslint-plugin-react-hooks
+    # publishes a release that accepts eslint@^10, then follow up
+    # with a manual eslint-ecosystem upgrade PR.
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
     groups:
       react:
         patterns:


### PR DESCRIPTION
## Summary

Dependabot has opened the same unmergeable ESLint 9→10 bump four times now (PRs #95, #93, #104, #108). The root cause is upstream, not ours: `eslint-plugin-react-hooks@7.0.1` declares a peer dep that does not accept `eslint@^10`, so any grouped dev-tools PR that tries to land ESLint 10 fails \`npm ci\` with ERESOLVE.

Rather than burn CI minutes on the same broken PR every week, this adds a targeted Dependabot `ignore` rule for semver-major bumps on `eslint` and `@eslint/js`. Minor and patch updates (9.39.x → 9.40.x, etc.) still flow through normally.

## What changed

Added an `ignore` block to the `/frontend` npm section of `.github/dependabot.yml`:

\`\`\`yaml
ignore:
  - dependency-name: \"eslint\"
    update-types: [\"version-update:semver-major\"]
  - dependency-name: \"@eslint/js\"
    update-types: [\"version-update:semver-major\"]
\`\`\`

A TODO comment above the block records the removal condition: drop the ignore once `eslint-plugin-react-hooks` publishes a release accepting `eslint@^10`, then follow up with a manual ecosystem upgrade PR.

## Type of Change
- [x] CI/CD or configuration change

## Why not upgrade now

Ran through the options:

1. **Manually upgrade eslint to 10 with `--legacy-peer-deps`** — risky, the plugin isn't actually compatible, behavior could break at runtime.
2. **Bump `eslint-plugin-react-hooks` first** — no published version exists yet that accepts eslint 10; nothing to bump to.
3. **Stay on eslint 9 and ignore the major bump** — this PR. Lowest risk, cleanest state, single-line rollback when upstream is ready.

## Verification

- [x] YAML still parses (indent / tab sanity check)
- [x] No code changes, no lock file changes
- [x] Dependabot will see the rule on the next run (Monday 09:00 UTC) and skip opening another ESLint major PR

## Follow-up

Once \`eslint-plugin-react-hooks\` publishes a compatible release:
1. Drop the \`ignore\` block from \`.github/dependabot.yml\`
2. Open a manual PR: \`npm install --save-dev eslint@^10 @eslint/js@^10 eslint-plugin-react-hooks@latest typescript-eslint@latest\`
3. Run \`npm run lint && npm run build\` to verify
4. Merge