### PR TITLE
chore(ci): only open auto-issues on main regressions, not PR failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,10 @@ jobs:
           echo "All relevant CI checks passed."
 
       - name: Create Issue on Failure
-        if: failure()
+        # Only open auto-issues when main itself regresses. PR failures
+        # are already visible as red checks on the PR; opening an issue
+        # on every PR failure duplicates signal and floods the tracker.
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -205,7 +205,11 @@ jobs:
           fi
 
       - name: Create Issue on Security Failure
-        if: failure()
+        # Only open auto-issues when main itself regresses, or when the
+        # weekly scheduled scan finds a new vulnerability. PR failures
+        # are already visible as red checks on the PR; opening an issue
+        # on every PR failure duplicates signal and floods the tracker.
+        if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## Summary

One Dependabot cycle today generated **12 duplicate auto-issues** on top of the underlying PR problems. Root cause: the \`ci-summary\` and \`security-summary\` jobs were opening a GitHub issue on every \`failure()\`, including PR failures, and the dedup key (\"title contains branch name\") couldn't coalesce issues across 7+ different Dependabot branches.

PR failures already surface as **red checks on the PR page** — that's the correct place for per-PR signal. Issues should be reserved for \"main regressed\" or \"new vulnerability found on schedule\".

## What changed

Two files, two \`if:\` conditions:

### \`.github/workflows/ci.yml\`
\`\`\`diff
  - name: Create Issue on Failure
-   if: failure()
+   if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
    uses: actions/github-script@v9
\`\`\`

### \`.github/workflows/security.yml\`
\`\`\`diff
  - name: Create Issue on Security Failure
-   if: failure()
+   if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
    uses: actions/github-script@v9
\`\`\`

The \`security.yml\` condition also keeps \`schedule\` events so the **weekly scheduled scan** (Mondays 09:00 UTC) still opens an issue when it finds a new vulnerability — that's the one case where you actively want a tracker entry without a human pushing anything.

## Type of Change
- [x] CI/CD or configuration change

## Why not remove auto-issue-on-failure entirely?

Considered it. The argument for keeping it is real: when \`main\` goes red after a merge, you want a loud, trackable signal that's not buried in a PR conversation. Removing the feature would lose that. Narrowing the \`if:\` keeps the useful case (main regression + weekly scan finding) and kills the noisy case (PR failure spam).

Dedup logic inside the \`github-script\` call (title + branch matching, appending comments to existing issues) is untouched — still does its job for the narrower event set.

## Verification

- [x] YAML syntax valid (no tabs, no indentation drift)
- [x] Diff is minimal — only the \`if:\` lines and explanatory comments change
- [x] No changes to the dedup logic, issue title, body template, or labels
- [x] \`github-script@v9\` version unchanged

Once this merges, the auto-issue step will only fire in three conditions:

| Event | Will open issue on failure? |
|---|---|
| PR failure | **No** (red check on PR is sufficient) |
| Push to \`main\` failure (after merge) | **Yes** |
| Push to \`develop\` failure | No |
| Weekly scheduled security scan failure | **Yes** (security.yml only) |
| \`workflow_dispatch\` manual failure | No |

## Follow-up (separate PRs, not this one)

- Close the **12 stale auto-issues** from earlier today (already planned in previous conversation)
- Consider raising the dedup window if real main regressions ever start producing multiple issues (low priority — current logic is fine for the narrower event set)