### PR TITLE
docs(plan): fold compose follow-ups back into PROJECT_CHECKLIST

### DIFF
--- a/plan/PROJECT_CHECKLIST.md
+++ b/plan/PROJECT_CHECKLIST.md
@@ -1,7 +1,7 @@
 # Personal Finance Tracker - Master Checklist
 
 > **Purpose**: Track all tasks, milestones, and deliverables across the entire project lifecycle.
-> **Last Updated**: 2026-04-03
+> **Last Updated**: 2026-04-14
 > **Current Phase**: Phase 0 - Planning Complete, Backend Hybrid Setup Configured
 
 ---
@@ -41,8 +41,24 @@
   - [x] Build plugins configured
 - [x] Set up package.json dependencies
 - [ ] Create docker-compose.yml
+  - Scope for the initial compose (local dev only):
+    - [ ] Backend service (built from `backend/Dockerfile`, multi-stage Maven)
+    - [ ] MySQL 8.4 service with named volume for persistence
+    - [ ] Redis 7 service (infrastructure ready — backend wiring lands in Phase 1 Redis Setup)
+    - [ ] Isolated bridge network, healthcheck-gated `depends_on`
+    - [ ] Env-overridable ports via `.env` (MYSQL_PORT / REDIS_PORT / BACKEND_PORT)
+  - Intentionally **out of scope** for the initial compose (design decisions):
+    - Frontend service — deployment target is Vercel; local dev uses `npm run dev` for hot reload
+    - Production compose / Kubernetes manifests — tracked under Production Deployment below
+    - Observability sidecar (Prometheus / Grafana / Loki) — tracked under Monitoring Setup below
+  - DevOps follow-ups (post-MVP, optional, low priority):
+    - [ ] Add `docker-compose.override.yml` for per-developer customizations (custom ports, volume mounts, debug flags)
+    - [ ] Switch the E2E workflow from jar + `vite preview` to `docker compose up` so CI and local dev use the identical stack
 - [ ] Set up .gitignore
 - [ ] Create .env.example files
+  - [ ] Root-level `.env.example` for docker-compose variables
+  - [ ] `backend/.env.example` for Spring Boot profile overrides (if/when needed)
+  - [ ] `frontend/.env.example` for `VITE_*` variables
 - [x] Initialize Git repository
 
 ### Documentation
@@ -91,11 +107,14 @@
 - [ ] Write integration tests for auth endpoints
 
 #### Redis Setup
-- [ ] Configure Redis connection
+> The Redis **container** is already provisioned by `docker-compose.yml` (Phase 0).
+> The tasks below wire the backend application to that container.
+- [ ] Add `spring-boot-starter-data-redis` dependency to `backend/pom.xml`
+- [ ] Configure Redis connection (host: `cache`, port: `6379` inside compose network)
 - [ ] Set up RedisTemplate
 - [ ] Implement session storage
 - [ ] Implement rate limiting cache
-- [ ] Test Redis connection
+- [ ] Test Redis connection from backend container
 - [ ] Configure Redis for development/production
 
 ### Week 3-4: Frontend Foundation
@@ -416,6 +435,8 @@
 - [ ] Environment variables documented and secured
 - [ ] Database migration strategy tested
 - [ ] SSL/TLS certificates obtained and configured
+  - [ ] Pick a reverse proxy strategy: Traefik / nginx / Caddy / platform-managed (Railway, Render)
+  - [ ] Enforce HSTS + redirect HTTP → HTTPS
 - [ ] Domain name registered and DNS configured
 - [ ] Backup strategy implemented and tested
 - [ ] Monitoring and logging configured
@@ -423,6 +444,10 @@
 - [ ] CORS policies reviewed
 - [ ] Security headers configured
 - [ ] Error tracking setup (Sentry or similar)
+- [ ] Production orchestration manifests
+  - [ ] Production `docker-compose.prod.yml` (or Kubernetes manifests if using K8s — see IMPLEMENTATION_PLAN.md "DevOps (Post-MVP): Full Stack")
+  - [ ] Secrets delivered via env / secret manager, never baked into images
+  - [ ] Image tagging strategy (git SHA, semver) instead of `:latest`
 
 ### Deployment Steps
 - [ ] Database backed up before migration
@@ -445,6 +470,7 @@
 ### Monitoring Setup
 - [ ] Configure error tracking (Sentry/Rollbar)
 - [ ] Configure performance monitoring (New Relic/DataDog)
+  - Self-hosted alternative: Prometheus + Grafana (metrics) + Loki (logs) + Alertmanager — decision deferred until production infrastructure choice is made
 - [ ] Configure uptime monitoring (UptimeRobot/Pingdom)
 - [ ] Configure log aggregation
 - [ ] Set up critical alerts (email/SMS)


### PR DESCRIPTION
## Summary

PR #120 (docker-compose local dev stack) left a list of deferred follow-ups in its body. Rather than open a bunch of GitHub issues that would compete with `plan/PROJECT_CHECKLIST.md` as the task source of truth, this PR folds **every single follow-up** back into the existing checklist as sub-bullets of items that were already there.

No new top-level categories, no renames, no deletions. Just +29 / -3 lines that make the checklist tell the full story.

## Type of Change
- [x] Documentation update
- [ ] CI/CD or configuration change (no workflow / tooling changes)

## How each follow-up was handled

| Follow-up from PR #120 | Handling | Location in PROJECT_CHECKLIST |
|---|---|---|
| **Production compose / K8s manifests** | Added as new top-level item under Pre-Production Checklist | Production Deployment → Pre-Production → "Production orchestration manifests" |
| **CI integration for compose-based tests** | Added as optional post-MVP follow-up sub-bullet under the compose scope | Phase 0 → "Create docker-compose.yml" → DevOps follow-ups |
| **Frontend containerization** | **Not tracked** — explicit design decision (Vercel is the deployment target) | Called out as OOS under "Create docker-compose.yml" |
| **Observability stack (Prometheus / Grafana / Loki)** | Added as self-hosted alternative note | Monitoring Setup → under "Configure performance monitoring" |
| **TLS termination / reverse proxy** | Added as sub-bullets (choice + HSTS) under existing SSL/TLS line | Pre-Production Checklist → under "SSL/TLS certificates obtained and configured" |
| **`docker-compose.override.yml`** | Added as optional follow-up sub-bullet | Phase 0 → "Create docker-compose.yml" → DevOps follow-ups |
| **Frontend service in compose** | **Not tracked** — explicit design decision (local uses `npm run dev`) | Called out as OOS under "Create docker-compose.yml" |
| **Redis wiring into backend** | Expanded existing Phase 1 Redis Setup tasks with a clarifying note + explicit first sub-task | Phase 1 → "Redis Setup" |

**Zero GitHub issues opened.** Everything lives in the plan file.

## Diff overview

- **Phase 0 → Project Initialization**
  - Expand `Create docker-compose.yml` with explicit scope / OOS / follow-ups subtree
  - Expand `Create .env.example files` into three files (root, backend, frontend)
- **Phase 1 → Redis Setup**
  - Add a note: the Redis container already exists via compose; the remaining tasks wire the Spring Boot app to it
  - Add explicit first sub-task: add `spring-boot-starter-data-redis` to `pom.xml`
- **Production Deployment → Pre-Production Checklist**
  - Add reverse proxy choice + HSTS sub-bullets under existing SSL/TLS line
  - Add new "Production orchestration manifests" top-level item with sub-bullets for compose.prod.yml, secrets delivery, image tagging
- **Production Deployment → Monitoring Setup**
  - Add self-hosted Prom+Grafana+Loki+Alertmanager alternative note under existing performance monitoring line
- Header: bump `Last Updated` to 2026-04-14

## Verification

- [x] Diff is additive — no existing item was deleted or renamed
- [x] Markdown still renders (no broken list indentation — local preview clean)
- [x] Cross-reference to `IMPLEMENTATION_PLAN.md` "DevOps (Post-MVP)" section is valid
- [x] No code, workflow, or configuration changes — plan file only

## Why not open issues

The user explicitly asked: "if you can add to existing places, add there. If it doesn't fit anywhere and you can't add it, don't open issues." Every follow-up had a sensible home in the existing checklist (or was an explicit OOS design decision), so nothing needed its own issue. Keeping `plan/PROJECT_CHECKLIST.md` as the single source of truth avoids the split-brain problem where some tasks live in the plan file and others live as GitHub issues.

## Depends on

This PR is documentation-only and does not depend on #120 merging first. The wording under "Create docker-compose.yml" describes the compose stack that PR #120 ships — if PR #120 is still open when this merges, the checklist will describe the intended state and become fully accurate the moment PR #120 lands.