### PR TITLE
docs(plan): add frontend service to docker-compose follow-ups

### DIFF
--- a/plan/PROJECT_CHECKLIST.md
+++ b/plan/PROJECT_CHECKLIST.md
@@ -48,10 +48,16 @@
     - [ ] Isolated bridge network, healthcheck-gated `depends_on`
     - [ ] Env-overridable ports via `.env` (MYSQL_PORT / REDIS_PORT / BACKEND_PORT)
   - Intentionally **out of scope** for the initial compose (design decisions):
-    - Frontend service — deployment target is Vercel; local dev uses `npm run dev` for hot reload
     - Production compose / Kubernetes manifests — tracked under Production Deployment below
     - Observability sidecar (Prometheus / Grafana / Loki) — tracked under Monitoring Setup below
   - DevOps follow-ups (post-MVP, optional, low priority):
+    - [ ] Add frontend service to `docker-compose.yml`
+      - [ ] `frontend/Dockerfile` — multi-stage: node build (`npm ci && npm run build`) → nginx/caddy runtime serving `dist/`
+      - [ ] Build-time `VITE_API_URL` arg pointing at the `backend` service inside the compose network
+      - [ ] Runtime port overridable via `FRONTEND_PORT` in `.env` (default 5173 or 8081 to avoid colliding with Vite dev server)
+      - [ ] `frontend/.dockerignore` excluding `node_modules/`, `dist/`, coverage, etc.
+      - [ ] Keep `npm run dev` as the primary local workflow — compose frontend is for full-stack demos and parity checks, not daily dev
+      - [ ] Vercel remains the production deployment target; this service is local/compose-only
     - [ ] Add `docker-compose.override.yml` for per-developer customizations (custom ports, volume mounts, debug flags)
     - [ ] Switch the E2E workflow from jar + `vite preview` to `docker compose up` so CI and local dev use the identical stack
 - [ ] Set up .gitignore


### PR DESCRIPTION
## Summary

Reverses the earlier \"frontend compose is out of scope\" decision (PR #121) and instead tracks it as an explicit post-MVP follow-up under the existing compose section in \`plan/PROJECT_CHECKLIST.md\`.

The reasoning hasn't changed — Vercel is still the production deploy target, \`npm run dev\` still gives hot reload — but it's worth having a frontend compose service for full-stack demos, parity checks, and CI experiments where starting the frontend the same way as production is useful.

## Type of Change
- [x] Documentation update

## Changes

### \`plan/PROJECT_CHECKLIST.md\` — Phase 0 → \"Create docker-compose.yml\"

**Removed** (no longer OOS):
\`\`\`diff
- Frontend service — deployment target is Vercel; local dev uses `npm run dev` for hot reload
\`\`\`

**Added** (new trackable task tree under \"DevOps follow-ups\"):

- [ ] Add frontend service to \`docker-compose.yml\`
  - [ ] \`frontend/Dockerfile\` — multi-stage: node build (\`npm ci && npm run build\`) → nginx/caddy runtime serving \`dist/\`
  - [ ] Build-time \`VITE_API_URL\` arg pointing at the \`backend\` service inside the compose network
  - [ ] Runtime port overridable via \`FRONTEND_PORT\` in \`.env\` (default 5173 or 8081 to avoid colliding with Vite dev server)
  - [ ] \`frontend/.dockerignore\` excluding \`node_modules/\`, \`dist/\`, coverage, etc.
  - [ ] Keep \`npm run dev\` as the primary local workflow — compose frontend is for full-stack demos and parity checks, not daily dev
  - [ ] Vercel remains the production deployment target; this service is local/compose-only

## Diff size

+7 / -1 lines, single file.

## Why a plan update and not an implementation PR?

Same reasoning as PR #121: \`PROJECT_CHECKLIST.md\` is the source of truth for tracked work. Landing the task in the checklist first makes the intent explicit and gives us a reference to point at when the implementation PR is opened. No GitHub issue needed.

The actual implementation (Dockerfile + compose service entry + \`.env.example\` addition + docs) lands in a follow-up PR when we're ready to build it.

## Verification

- [x] Diff is minimal — one line removed, seven added, no existing item renamed
- [x] Markdown list indentation clean (local preview, no broken nesting)
- [x] No workflow / code / config changes

## Depends on

Nothing — this is a doc-only change on top of current main, which already contains both PR #120 (compose stack) and PR #121 (plan follow-ups).