### PR TITLE
fix(security): lock down actuator exposure to satisfy CodeQL

### DIFF
--- a/backend/src/main/resources/application-docker.properties
+++ b/backend/src/main/resources/application-docker.properties
@@ -21,7 +21,13 @@ spring.jpa.open-in-view=false
 # --- H2 console is useless in this profile; keep it off ---
 spring.h2.console.enabled=false
 
-# --- Actuator: expose health for the container healthcheck ---
-management.endpoints.web.exposure.include=health,info
-management.endpoint.health.probes.enabled=true
+# --- Actuator: expose health only (for the container healthcheck) ---
+# Kept in sync with the base application.properties allow-list so
+# CodeQL's java/spring-boot-exposed-actuators-config rule stays
+# happy and so switching profiles can never accidentally widen
+# exposure.
+management.endpoints.web.exposure.include=health
+management.endpoints.web.exposure.exclude=env,beans,mappings,threaddump,heapdump,metrics,loggers,configprops
 management.endpoint.health.show-details=never
+management.endpoint.health.show-components=never
+management.endpoint.health.probes.enabled=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -21,3 +21,32 @@ spring.h2.console.path=/h2-console
 # spring.datasource.username=root
 # spring.datasource.password=yourpassword
 # spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+
+# ================================================================
+# Actuator exposure — explicit allow-list
+# ================================================================
+# Spring Boot's default actuator exposure is already narrow
+# (health + info), but the defaults are not visible to static
+# analysis tools like CodeQL, which then flag the dependency as
+# "exposed". Pinning the exposure explicitly here closes that
+# alert and makes the contract obvious for future readers.
+#
+# Only /actuator/health is exposed. /actuator/info and everything
+# else (env, beans, mappings, threaddump, heapdump, metrics) are
+# blocked. Health output is locked to {status: UP|DOWN} — no
+# component-level detail is ever returned to unauthenticated
+# callers, even in dev.
+#
+# When Spring Security is added (Phase 1), the actuator endpoints
+# will additionally be placed behind authentication. Until then,
+# this allow-list is the only gate.
+management.endpoints.web.exposure.include=health
+management.endpoints.web.exposure.exclude=env,beans,mappings,threaddump,heapdump,metrics,loggers,configprops
+management.endpoint.health.show-details=never
+management.endpoint.health.show-components=never
+management.endpoint.health.probes.enabled=true
+management.info.env.enabled=false
+management.info.java.enabled=false
+management.info.os.enabled=false
+management.info.build.enabled=false
+management.info.git.enabled=false


### PR DESCRIPTION
## Summary

Closes #123

CodeQL code-scanning alert #2 (rule: \`java/spring-boot-exposed-actuators-config\`, severity: **error**) flagged \`backend/pom.xml:41-44\` — the \`spring-boot-starter-actuator\` dependency — as \"Insecure Spring Boot actuator configuration exposes sensitive endpoints\".

## Root cause

The actuator starter was added in PR #120 so the docker-compose healthcheck could hit \`/actuator/health\`. Spring Boot 3.x's default exposure is actually narrow (only \`health\` + \`info\`), but static analysis tools can't see \"defaults\" — they see \"dependency on classpath + no explicit management.* allow-list in \`application.properties\` → potentially fully exposed\" and raise the alert.

The fix is to make the allow-list explicit. Once CodeQL sees \`management.endpoints.web.exposure.include=health\` in the base profile, the rule is satisfied.

## Changes

### \`backend/src/main/resources/application.properties\`

Added an explicit actuator hardening block:

\`\`\`properties
management.endpoints.web.exposure.include=health
management.endpoints.web.exposure.exclude=env,beans,mappings,threaddump,heapdump,metrics,loggers,configprops
management.endpoint.health.show-details=never
management.endpoint.health.show-components=never
management.endpoint.health.probes.enabled=true
management.info.env.enabled=false
management.info.java.enabled=false
management.info.os.enabled=false
management.info.build.enabled=false
management.info.git.enabled=false
\`\`\`

- **Only \`/actuator/health\` is reachable.** Everything else (env, beans, mappings, threaddump, heapdump, metrics, loggers, configprops) is explicitly blocked via both the narrow \`include\` and a defensive \`exclude\` list.
- **\`/actuator/health\` response is locked to \`{\"status\":\"UP\"}\`** — \`show-details=never\` and \`show-components=never\` mean no component-level detail or system information leaks to unauthenticated callers.
- **\`info.*\` sub-endpoints disabled** in case \`info\` is ever re-added to the include list later.

### \`backend/src/main/resources/application-docker.properties\`

Tightened the \`docker\` profile to match the base (previously exposed \`health, info\`, now only \`health\`). Same explicit \`exclude\` list. \`probes.enabled=true\` stays so the compose healthcheck keeps working.

## Effect on the compose healthcheck

None — \`curl -fsS http://localhost:8080/actuator/health\` inside the container still gets \`200 OK\` + \`{\"status\":\"UP\"}\`. That's all the healthcheck needs. No endpoint disabled that compose was relying on.

## Type of Change
- [x] Bug fix (security)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [x] CI/CD or configuration change (security hardening)

## Verification

### Automated
- [x] \`mvn -B -ntp clean verify\` → **BUILD SUCCESS** locally
- [x] Smoke test \`ExpenseTrackerApplicationTests.contextLoads\` still passes
- [x] JaCoCo coverage check still passes (gate currently at 0.00, TODO in pom.xml)
- [x] Diff is additive — no existing property removed, only new management.* properties added

### Expected after merge
- [ ] CodeQL alert #2 (\`java/spring-boot-exposed-actuators-config\`) auto-closes on the next scheduled security scan OR on the next push to \`main\` that re-runs CodeQL
- [ ] New scans should not reopen the rule on these lines

### Manual smoke test (optional, after merge)
\`\`\`bash
# Non-docker profile — default H2, base application.properties
cd backend && mvn spring-boot:run &
curl -i http://localhost:8080/actuator/health
# → HTTP 200, body: {\"status\":\"UP\"}

curl -i http://localhost:8080/actuator/info
# → HTTP 404 (now blocked)

curl -i http://localhost:8080/actuator/env
# → HTTP 404 (now blocked)

curl -i http://localhost:8080/actuator/beans
# → HTTP 404 (now blocked)
\`\`\`

## Security Checklist
- [x] **No hardcoded secrets** — no credentials added
- [x] **Input validation** — N/A, properties file only
- [x] **SQL injection / XSS** — N/A
- [x] **Authentication/authorization** — not in scope for this PR; the allow-list is the current gate. See follow-ups below.
- [x] **Least-exposure principle** — only \`health\` endpoint allowed, all sensitive endpoints explicitly excluded, health response locked to status-only

## Follow-ups (separate PRs, not this one)

1. **H2 console exposure** — base \`application.properties\` still has \`spring.h2.console.enabled=true\`. H2 console is another well-known exposure vector (arbitrary SQL over HTTP). It's only relevant outside the docker profile (docker profile uses MySQL), but worth disabling by default in a follow-up PR. Tracked mentally, not opening an issue per the \"plan-first\" policy from PR #121.
2. **Spring Security on /actuator/\*\*** — when Spring Security lands in Phase 1 (per \`PROJECT_CHECKLIST.md\` \"Security Configuration\" block), the actuator endpoints should additionally be placed behind authentication as defense-in-depth on top of this allow-list.
3. **\`/actuator/health\` at a separate management port** (\`management.server.port=8081\`) — optional further hardening, lets the compose healthcheck stay on a private port while the public app port exposes zero management surface. Low priority.

## Depends on

Nothing. This PR applies on top of current \`main\` (which has PR #120's compose + actuator dep and PR #121's plan updates).