### PR TITLE
fix(ci): pin owasp dependency-check to 12.1.3 + wire NVD API key

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -76,9 +76,26 @@ jobs:
             owasp-nvd-${{ runner.os }}-
 
       - name: Backend - OWASP Dependency Check
+        # Pinned to 12.1.3 — the last release before the nanosecond-timestamp
+        # regression in 12.2.x's openvulnerability-client (it can't parse
+        # 9-digit fractional seconds in the NVD API response, the parser
+        # only accepts up to milliseconds). Re-evaluate when the upstream
+        # fix lands (track: jeremylong/DependencyCheck).
+        # TODO: revisit quarterly; roll forward when a newer version is safe.
         if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true' }}
         working-directory: ./backend
-        run: mvn -B -ntp org.owasp:dependency-check-maven:check
+        env:
+          # Authenticated NVD tier — higher rate limits, faster cold-cache
+          # update, and a different serverside path that sidesteps the
+          # nanosecond-timestamp regression on the anonymous tier.
+          # Optional: if the secret is unset (e.g. on forks), the shell
+          # default expansion below leaves the flag empty and the plugin
+          # falls back to anonymous mode without erroring out.
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: |
+          mvn -B -ntp \
+            org.owasp:dependency-check-maven:12.1.3:check \
+            -DnvdApiKey="${NVD_API_KEY:-}"
 
       - name: Upload Backend Security Report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ npm-debug.log*
 # Maven
 backend/*.jar
 
+# H2 file-based database (local dev data — never commit)
+backend/data/
+*.mv.db
+*.trace.db
+
 # Misc
 *.class
 *.war

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -55,6 +55,31 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- Security: JWT (jjwt) + BCrypt password hashing.
+             spring-security-crypto is a standalone module (BCryptPasswordEncoder)
+             and does NOT pull in the full Spring Security filter chain. -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/backend/src/main/java/com/expensetracker/config/WebConfig.java
+++ b/backend/src/main/java/com/expensetracker/config/WebConfig.java
@@ -1,0 +1,53 @@
+package com.expensetracker.config;
+
+import com.expensetracker.security.CurrentUserArgumentResolver;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+/**
+ * CORS configuration and shared web beans.
+ *
+ * <p>The frontend runs on a different origin (Vite dev server on :5173),
+ * so browsers block API calls unless the backend explicitly allows that
+ * origin. Auth uses Bearer tokens in the Authorization header (not
+ * cookies), so credentials are not required.
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final String[] allowedOrigins;
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    public WebConfig(@Value("${app.cors.allowed-origins}") String[] allowedOrigins,
+                     CurrentUserArgumentResolver currentUserArgumentResolver) {
+        this.allowedOrigins = allowedOrigins;
+        this.currentUserArgumentResolver = currentUserArgumentResolver;
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(allowedOrigins)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .maxAge(3600);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/expensetracker/controller/AuthController.java
+++ b/backend/src/main/java/com/expensetracker/controller/AuthController.java
@@ -1,0 +1,60 @@
+package com.expensetracker.controller;
+
+import com.expensetracker.dto.ApiResponse;
+import com.expensetracker.dto.AuthResponse;
+import com.expensetracker.dto.LoginRequest;
+import com.expensetracker.dto.RefreshRequest;
+import com.expensetracker.dto.RegisterRequest;
+import com.expensetracker.dto.UserDto;
+import com.expensetracker.security.CurrentUser;
+import com.expensetracker.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+/**
+ * Authentication endpoints. All responses use the {@link ApiResponse}
+ * envelope expected by the frontend.
+ */
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse<AuthResponse>> register(@Valid @RequestBody RegisterRequest request) {
+        AuthResponse response = authService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<AuthResponse>> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(authService.login(request)));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserDto>> me(@CurrentUser UUID userId) {
+        return ResponseEntity.ok(ApiResponse.ok(authService.getCurrentUser(userId)));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<AuthResponse>> refresh(@Valid @RequestBody RefreshRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(authService.refresh(request.getRefreshToken())));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout() {
+        // Tokens are stateless JWTs; the client discards them. This endpoint
+        // exists so the frontend has a stable contract and future token
+        // revocation can be added here without a client change.
+        return ResponseEntity.ok(ApiResponse.ok(null, "Logged out"));
+    }
+}

--- a/backend/src/main/java/com/expensetracker/controller/CategoryController.java
+++ b/backend/src/main/java/com/expensetracker/controller/CategoryController.java
@@ -1,0 +1,50 @@
+package com.expensetracker.controller;
+
+import com.expensetracker.dto.ApiResponse;
+import com.expensetracker.dto.CategoryDto;
+import com.expensetracker.dto.CategoryRequest;
+import com.expensetracker.security.CurrentUser;
+import com.expensetracker.service.CategoryService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CategoryDto>>> list(@CurrentUser UUID userId) {
+        return ResponseEntity.ok(ApiResponse.ok(categoryService.list(userId)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CategoryDto>> create(@CurrentUser UUID userId,
+                                                           @Valid @RequestBody CategoryRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(categoryService.create(userId, request)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<CategoryDto>> update(@CurrentUser UUID userId,
+                                                           @PathVariable UUID id,
+                                                           @Valid @RequestBody CategoryRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(categoryService.update(userId, id, request)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> delete(@CurrentUser UUID userId, @PathVariable UUID id) {
+        categoryService.delete(userId, id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Category deleted"));
+    }
+}

--- a/backend/src/main/java/com/expensetracker/controller/SubCategoryController.java
+++ b/backend/src/main/java/com/expensetracker/controller/SubCategoryController.java
@@ -1,0 +1,52 @@
+package com.expensetracker.controller;
+
+import com.expensetracker.dto.ApiResponse;
+import com.expensetracker.dto.SubCategoryDto;
+import com.expensetracker.dto.SubCategoryRequest;
+import com.expensetracker.security.CurrentUser;
+import com.expensetracker.service.SubCategoryService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/subcategories")
+public class SubCategoryController {
+
+    private final SubCategoryService subCategoryService;
+
+    public SubCategoryController(SubCategoryService subCategoryService) {
+        this.subCategoryService = subCategoryService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<SubCategoryDto>>> list(
+            @CurrentUser UUID userId,
+            @RequestParam(value = "categoryId", required = false) UUID categoryId) {
+        return ResponseEntity.ok(ApiResponse.ok(subCategoryService.list(userId, categoryId)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<SubCategoryDto>> create(@CurrentUser UUID userId,
+                                                              @Valid @RequestBody SubCategoryRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(subCategoryService.create(userId, request)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<SubCategoryDto>> update(@CurrentUser UUID userId,
+                                                              @PathVariable UUID id,
+                                                              @Valid @RequestBody SubCategoryRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(subCategoryService.update(userId, id, request)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> delete(@CurrentUser UUID userId, @PathVariable UUID id) {
+        subCategoryService.delete(userId, id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Sub-category deleted"));
+    }
+}

--- a/backend/src/main/java/com/expensetracker/controller/TransactionController.java
+++ b/backend/src/main/java/com/expensetracker/controller/TransactionController.java
@@ -1,0 +1,60 @@
+package com.expensetracker.controller;
+
+import com.expensetracker.dto.ApiResponse;
+import com.expensetracker.dto.TransactionDto;
+import com.expensetracker.dto.TransactionRequest;
+import com.expensetracker.model.TransactionType;
+import com.expensetracker.security.CurrentUser;
+import com.expensetracker.service.TransactionService;
+import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/transactions")
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    public TransactionController(TransactionService transactionService) {
+        this.transactionService = transactionService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<TransactionDto>>> list(
+            @CurrentUser UUID userId,
+            @RequestParam(value = "categoryId", required = false) UUID categoryId,
+            @RequestParam(value = "subCategoryId", required = false) UUID subCategoryId,
+            @RequestParam(value = "type", required = false) TransactionType type,
+            @RequestParam(value = "from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(value = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                transactionService.list(userId, categoryId, subCategoryId, type, from, to)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<TransactionDto>> create(@CurrentUser UUID userId,
+                                                              @Valid @RequestBody TransactionRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(transactionService.create(userId, request)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<TransactionDto>> update(@CurrentUser UUID userId,
+                                                              @PathVariable UUID id,
+                                                              @Valid @RequestBody TransactionRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(transactionService.update(userId, id, request)));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> delete(@CurrentUser UUID userId, @PathVariable UUID id) {
+        transactionService.delete(userId, id);
+        return ResponseEntity.ok(ApiResponse.ok(null, "Transaction deleted"));
+    }
+}

--- a/backend/src/main/java/com/expensetracker/dto/ApiResponse.java
+++ b/backend/src/main/java/com/expensetracker/dto/ApiResponse.java
@@ -1,0 +1,32 @@
+package com.expensetracker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Standard response envelope consumed by the frontend:
+ * {@code { success, data, error, message }}.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private boolean success;
+    private T data;
+    private String error;
+    private String message;
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, data, null, null);
+    }
+
+    public static <T> ApiResponse<T> ok(T data, String message) {
+        return new ApiResponse<>(true, data, null, message);
+    }
+
+    public static <T> ApiResponse<T> fail(String error) {
+        return new ApiResponse<>(false, null, error, null);
+    }
+}

--- a/backend/src/main/java/com/expensetracker/dto/AuthResponse.java
+++ b/backend/src/main/java/com/expensetracker/dto/AuthResponse.java
@@ -1,0 +1,19 @@
+package com.expensetracker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Payload returned by /auth/login, /auth/register and /auth/refresh.
+ * Matches the frontend {@code AuthResponse} type.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthResponse {
+
+    private UserDto user;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/expensetracker/dto/CategoryDto.java
+++ b/backend/src/main/java/com/expensetracker/dto/CategoryDto.java
@@ -1,0 +1,40 @@
+package com.expensetracker.dto;
+
+import com.expensetracker.model.Bucket;
+import com.expensetracker.model.Category;
+import com.expensetracker.model.CategoryKind;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryDto {
+
+    private String id;
+    private String name;
+    private CategoryKind kind;
+    private Bucket bucket;
+    private String icon;
+    private String color;
+
+    @JsonProperty("isSystem")
+    private boolean isSystem;
+
+    private int sortOrder;
+
+    public static CategoryDto from(Category c) {
+        return new CategoryDto(
+                c.getId().toString(),
+                c.getName(),
+                c.getKind(),
+                c.getBucket(),
+                c.getIcon(),
+                c.getColor(),
+                c.isSystem(),
+                c.getSortOrder()
+        );
+    }
+}

--- a/backend/src/main/java/com/expensetracker/dto/CategoryRequest.java
+++ b/backend/src/main/java/com/expensetracker/dto/CategoryRequest.java
@@ -1,0 +1,26 @@
+package com.expensetracker.dto;
+
+import com.expensetracker.model.Bucket;
+import com.expensetracker.model.CategoryKind;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class CategoryRequest {
+
+    @NotBlank(message = "Name is required")
+    @Size(max = 100, message = "Name must be at most 100 characters")
+    private String name;
+
+    @NotNull(message = "Kind is required (INCOME or EXPENSE)")
+    private CategoryKind kind;
+
+    @NotNull(message = "Bucket is required (INCOME, NEEDS, WANTS, SAVINGS, OTHER)")
+    private Bucket bucket;
+
+    private String icon;
+
+    private String color;
+}

--- a/backend/src/main/java/com/expensetracker/dto/LoginRequest.java
+++ b/backend/src/main/java/com/expensetracker/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.expensetracker.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be valid")
+    private String email;
+
+    @NotBlank(message = "Password is required")
+    private String password;
+}

--- a/backend/src/main/java/com/expensetracker/dto/RefreshRequest.java
+++ b/backend/src/main/java/com/expensetracker/dto/RefreshRequest.java
@@ -1,0 +1,11 @@
+package com.expensetracker.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class RefreshRequest {
+
+    @NotBlank(message = "Refresh token is required")
+    private String refreshToken;
+}

--- a/backend/src/main/java/com/expensetracker/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/expensetracker/dto/RegisterRequest.java
@@ -1,0 +1,24 @@
+package com.expensetracker.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class RegisterRequest {
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be valid")
+    private String email;
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, message = "Password must be at least 8 characters")
+    private String password;
+
+    @NotBlank(message = "First name is required")
+    private String firstName;
+
+    @NotBlank(message = "Last name is required")
+    private String lastName;
+}

--- a/backend/src/main/java/com/expensetracker/dto/SubCategoryDto.java
+++ b/backend/src/main/java/com/expensetracker/dto/SubCategoryDto.java
@@ -1,0 +1,37 @@
+package com.expensetracker.dto;
+
+import com.expensetracker.model.SubCategory;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubCategoryDto {
+
+    private String id;
+    private String categoryId;
+    private String name;
+    private String icon;
+    private String color;
+    private BigDecimal monthlyLimit;
+
+    @JsonProperty("isSystem")
+    private boolean isSystem;
+
+    public static SubCategoryDto from(SubCategory s) {
+        return new SubCategoryDto(
+                s.getId().toString(),
+                s.getCategoryId().toString(),
+                s.getName(),
+                s.getIcon(),
+                s.getColor(),
+                s.getMonthlyLimit(),
+                s.isSystem()
+        );
+    }
+}

--- a/backend/src/main/java/com/expensetracker/dto/SubCategoryRequest.java
+++ b/backend/src/main/java/com/expensetracker/dto/SubCategoryRequest.java
@@ -1,0 +1,29 @@
+package com.expensetracker.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Data
+public class SubCategoryRequest {
+
+    @NotNull(message = "categoryId is required")
+    private UUID categoryId;
+
+    @NotBlank(message = "Name is required")
+    @Size(max = 100, message = "Name must be at most 100 characters")
+    private String name;
+
+    private String icon;
+
+    private String color;
+
+    /** Optional monthly spending cap. When present it must be greater than 0. */
+    @DecimalMin(value = "0.0", inclusive = false, message = "Monthly limit must be greater than 0")
+    private BigDecimal monthlyLimit;
+}

--- a/backend/src/main/java/com/expensetracker/dto/TransactionDto.java
+++ b/backend/src/main/java/com/expensetracker/dto/TransactionDto.java
@@ -1,0 +1,48 @@
+package com.expensetracker.dto;
+
+import com.expensetracker.model.SourceType;
+import com.expensetracker.model.Transaction;
+import com.expensetracker.model.TransactionType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransactionDto {
+
+    private String id;
+    private String name;
+    private BigDecimal amount;
+    private String currency;
+    private String categoryId;
+    private String subCategoryId;
+    private TransactionType type;
+    private String transactionDate;
+    private String note;
+    private SourceType sourceType;
+    private Integer installmentNo;
+    private String createdAt;
+    private String updatedAt;
+
+    public static TransactionDto from(Transaction t) {
+        return new TransactionDto(
+                t.getId().toString(),
+                t.getName(),
+                t.getAmount(),
+                t.getCurrency(),
+                t.getCategoryId().toString(),
+                t.getSubCategoryId() != null ? t.getSubCategoryId().toString() : null,
+                t.getType(),
+                t.getTransactionDate().toString(),
+                t.getNote(),
+                t.getSourceType(),
+                t.getInstallmentNo(),
+                t.getCreatedAt().toString(),
+                t.getUpdatedAt().toString()
+        );
+    }
+}

--- a/backend/src/main/java/com/expensetracker/dto/TransactionRequest.java
+++ b/backend/src/main/java/com/expensetracker/dto/TransactionRequest.java
@@ -1,0 +1,41 @@
+package com.expensetracker.dto;
+
+import com.expensetracker.model.TransactionType;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+public class TransactionRequest {
+
+    @NotBlank(message = "Name is required")
+    @Size(max = 200, message = "Name must be at most 200 characters")
+    private String name;
+
+    @NotNull(message = "Amount is required")
+    @DecimalMin(value = "0.0", inclusive = false, message = "Amount must be greater than 0")
+    private BigDecimal amount;
+
+    @Size(min = 3, max = 3, message = "Currency must be a 3-letter code")
+    private String currency;
+
+    @NotNull(message = "categoryId is required")
+    private UUID categoryId;
+
+    private UUID subCategoryId;
+
+    @NotNull(message = "Type is required (INCOME or EXPENSE)")
+    private TransactionType type;
+
+    @NotNull(message = "Transaction date is required")
+    private LocalDate transactionDate;
+
+    @Size(max = 500, message = "Note must be at most 500 characters")
+    private String note;
+}

--- a/backend/src/main/java/com/expensetracker/dto/UserDto.java
+++ b/backend/src/main/java/com/expensetracker/dto/UserDto.java
@@ -1,0 +1,50 @@
+package com.expensetracker.dto;
+
+import com.expensetracker.model.User;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * User representation returned to the client. Deliberately excludes the
+ * password hash. JSON keys match the frontend {@code User} type exactly.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDto {
+
+    private String id;
+    private String email;
+    private String firstName;
+    private String lastName;
+    private String currency;
+    private String timezone;
+
+    // Explicit @JsonProperty so the boolean serializes as "isActive"
+    // (Jackson would otherwise strip the "is" prefix and emit "active").
+    @JsonProperty("isActive")
+    private boolean isActive;
+
+    @JsonProperty("emailVerified")
+    private boolean emailVerified;
+
+    private String createdAt;
+    private String updatedAt;
+
+    public static UserDto from(User user) {
+        return new UserDto(
+                user.getId().toString(),
+                user.getEmail(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getCurrency(),
+                user.getTimezone(),
+                user.isActive(),
+                user.isEmailVerified(),
+                user.getCreatedAt().toString(),
+                user.getUpdatedAt().toString()
+        );
+    }
+}

--- a/backend/src/main/java/com/expensetracker/exception/ApiException.java
+++ b/backend/src/main/java/com/expensetracker/exception/ApiException.java
@@ -1,0 +1,36 @@
+package com.expensetracker.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Base application exception carrying the HTTP status to return. Handled
+ * centrally by {@code GlobalExceptionHandler} and rendered as an
+ * {@code ApiResponse.fail} envelope.
+ */
+@Getter
+public class ApiException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    public ApiException(HttpStatus status, String message) {
+        super(message);
+        this.status = status;
+    }
+
+    public static ApiException notFound(String message) {
+        return new ApiException(HttpStatus.NOT_FOUND, message);
+    }
+
+    public static ApiException badRequest(String message) {
+        return new ApiException(HttpStatus.BAD_REQUEST, message);
+    }
+
+    public static ApiException conflict(String message) {
+        return new ApiException(HttpStatus.CONFLICT, message);
+    }
+
+    public static ApiException forbidden(String message) {
+        return new ApiException(HttpStatus.FORBIDDEN, message);
+    }
+}

--- a/backend/src/main/java/com/expensetracker/exception/AuthException.java
+++ b/backend/src/main/java/com/expensetracker/exception/AuthException.java
@@ -1,0 +1,15 @@
+package com.expensetracker.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Authentication/authorization failure (bad credentials, duplicate email,
+ * invalid/expired token). Specialisation of {@link ApiException} kept for
+ * semantic clarity at call sites.
+ */
+public class AuthException extends ApiException {
+
+    public AuthException(HttpStatus status, String message) {
+        super(status, message);
+    }
+}

--- a/backend/src/main/java/com/expensetracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/expensetracker/exception/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package com.expensetracker.exception;
+
+import com.expensetracker.dto.ApiResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Renders application errors as the {@link ApiResponse} envelope so every API
+ * error the frontend receives has a consistent {@code {success:false, error}}
+ * shape. Applies to all controllers.
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiResponse<Void>> handleApi(ApiException ex) {
+        return ResponseEntity.status(ex.getStatus()).body(ApiResponse.fail(ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex) {
+        FieldError fieldError = ex.getBindingResult().getFieldError();
+        String message = fieldError != null ? fieldError.getDefaultMessage() : "Validation failed";
+        return ResponseEntity.badRequest().body(ApiResponse.fail(message));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnreadable(HttpMessageNotReadableException ex) {
+        return ResponseEntity.badRequest().body(ApiResponse.fail("Malformed or invalid request body"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneric(Exception ex) {
+        log.error("Unhandled exception", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail("Internal server error"));
+    }
+}

--- a/backend/src/main/java/com/expensetracker/model/Bucket.java
+++ b/backend/src/main/java/com/expensetracker/model/Bucket.java
@@ -1,0 +1,15 @@
+package com.expensetracker.model;
+
+/**
+ * Budgeting bucket for the "rules for finance" (50/30/20) breakdown.
+ * INCOME is the money-in bucket; NEEDS/WANTS/SAVINGS are the three
+ * expense buckets compared against the user's target percentages;
+ * OTHER is an uncategorised expense fallback.
+ */
+public enum Bucket {
+    INCOME,
+    NEEDS,
+    WANTS,
+    SAVINGS,
+    OTHER
+}

--- a/backend/src/main/java/com/expensetracker/model/Category.java
+++ b/backend/src/main/java/com/expensetracker/model/Category.java
@@ -1,0 +1,72 @@
+package com.expensetracker.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Top-level spending/earning bucket owned by a user (e.g. Income, Needs,
+ * Wants, Savings, Other). Sub-categories hang off it.
+ */
+@Entity
+@Table(name = "categories", uniqueConstraints = {
+        @UniqueConstraint(name = "uq_category_user_name", columnNames = {"user_id", "name"})
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CategoryKind kind;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Bucket bucket;
+
+    private String icon;
+
+    private String color;
+
+    /** Reserved for future read-only defaults; P1 seeds are editable (false). */
+    @Column(name = "is_system", nullable = false)
+    private boolean system;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/expensetracker/model/CategoryKind.java
+++ b/backend/src/main/java/com/expensetracker/model/CategoryKind.java
@@ -1,0 +1,7 @@
+package com.expensetracker.model;
+
+/** Whether a category represents money coming in or going out. */
+public enum CategoryKind {
+    INCOME,
+    EXPENSE
+}

--- a/backend/src/main/java/com/expensetracker/model/SourceType.java
+++ b/backend/src/main/java/com/expensetracker/model/SourceType.java
@@ -1,0 +1,15 @@
+package com.expensetracker.model;
+
+/**
+ * How a transaction was created:
+ * <ul>
+ *   <li>MANUAL — entered directly by the user</li>
+ *   <li>RECURRING — generated from a {@code RecurringRule} (Epic 4)</li>
+ *   <li>INSTALLMENT — generated from an {@code InstallmentPlan} (Epic 5)</li>
+ * </ul>
+ */
+public enum SourceType {
+    MANUAL,
+    RECURRING,
+    INSTALLMENT
+}

--- a/backend/src/main/java/com/expensetracker/model/SubCategory.java
+++ b/backend/src/main/java/com/expensetracker/model/SubCategory.java
@@ -1,0 +1,68 @@
+package com.expensetracker.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Sub-division of a {@link Category} (e.g. Needs → Groceries). May carry an
+ * optional monthly spending limit used by the budgets feature (Epic 2).
+ */
+@Entity
+@Table(name = "sub_categories", uniqueConstraints = {
+        @UniqueConstraint(name = "uq_subcategory_category_name", columnNames = {"category_id", "name"})
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "category_id", nullable = false)
+    private UUID categoryId;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String icon;
+
+    private String color;
+
+    /** Monthly spending cap; null means "no limit". Must be > 0 when set. */
+    @Column(name = "monthly_limit", precision = 19, scale = 2)
+    private BigDecimal monthlyLimit;
+
+    @Column(name = "is_system", nullable = false)
+    private boolean system;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/expensetracker/model/Transaction.java
+++ b/backend/src/main/java/com/expensetracker/model/Transaction.java
@@ -1,0 +1,100 @@
+package com.expensetracker.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * A single money movement. Always belongs to a category; a sub-category is
+ * required only when the chosen category actually has sub-categories (enforced
+ * in the service layer). The {@code sourceType} + FK columns let recurring
+ * (Epic 4) and installment (Epic 5) engines link generated rows back to their
+ * origin without changing this shape.
+ */
+@Entity
+@Table(name = "transactions", indexes = {
+        @Index(name = "idx_tx_user_date", columnList = "user_id, transaction_date"),
+        @Index(name = "idx_tx_subcategory", columnList = "sub_category_id")
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Transaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal amount;
+
+    @Column(nullable = false, length = 3)
+    private String currency;
+
+    @Column(name = "category_id", nullable = false)
+    private UUID categoryId;
+
+    @Column(name = "sub_category_id")
+    private UUID subCategoryId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TransactionType type;
+
+    @Column(name = "transaction_date", nullable = false)
+    private LocalDate transactionDate;
+
+    @Column(length = 500)
+    private String note;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, length = 20)
+    private SourceType sourceType;
+
+    @Column(name = "recurring_rule_id")
+    private UUID recurringRuleId;
+
+    @Column(name = "installment_plan_id")
+    private UUID installmentPlanId;
+
+    @Column(name = "installment_no")
+    private Integer installmentNo;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+        if (currency == null) {
+            currency = "USD";
+        }
+        if (sourceType == null) {
+            sourceType = SourceType.MANUAL;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/expensetracker/model/TransactionType.java
+++ b/backend/src/main/java/com/expensetracker/model/TransactionType.java
@@ -1,0 +1,7 @@
+package com.expensetracker.model;
+
+/** Direction of a transaction. */
+public enum TransactionType {
+    INCOME,
+    EXPENSE
+}

--- a/backend/src/main/java/com/expensetracker/model/User.java
+++ b/backend/src/main/java/com/expensetracker/model/User.java
@@ -1,0 +1,73 @@
+package com.expensetracker.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Application user. Passwords are never stored in plain text — only the
+ * BCrypt hash lives in {@code passwordHash}.
+ */
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Column(name = "first_name", nullable = false)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(nullable = false)
+    private String currency;
+
+    @Column(nullable = false)
+    private String timezone;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+        if (currency == null) {
+            currency = "USD";
+        }
+        if (timezone == null) {
+            timezone = "UTC";
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/expensetracker/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/expensetracker/repository/CategoryRepository.java
@@ -1,0 +1,21 @@
+package com.expensetracker.repository;
+
+import com.expensetracker.model.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+
+    List<Category> findByUserIdOrderBySortOrderAscNameAsc(UUID userId);
+
+    Optional<Category> findByIdAndUserId(UUID id, UUID userId);
+
+    boolean existsByUserIdAndNameIgnoreCase(UUID userId, String name);
+
+    long countByUserId(UUID userId);
+}

--- a/backend/src/main/java/com/expensetracker/repository/SubCategoryRepository.java
+++ b/backend/src/main/java/com/expensetracker/repository/SubCategoryRepository.java
@@ -1,0 +1,23 @@
+package com.expensetracker.repository;
+
+import com.expensetracker.model.SubCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface SubCategoryRepository extends JpaRepository<SubCategory, UUID> {
+
+    List<SubCategory> findByUserIdOrderByNameAsc(UUID userId);
+
+    List<SubCategory> findByCategoryIdOrderByNameAsc(UUID categoryId);
+
+    Optional<SubCategory> findByIdAndUserId(UUID id, UUID userId);
+
+    boolean existsByCategoryIdAndNameIgnoreCase(UUID categoryId, String name);
+
+    long countByCategoryId(UUID categoryId);
+}

--- a/backend/src/main/java/com/expensetracker/repository/TransactionRepository.java
+++ b/backend/src/main/java/com/expensetracker/repository/TransactionRepository.java
@@ -1,0 +1,46 @@
+package com.expensetracker.repository;
+
+import com.expensetracker.model.Transaction;
+import com.expensetracker.model.TransactionType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, UUID> {
+
+    Optional<Transaction> findByIdAndUserId(UUID id, UUID userId);
+
+    boolean existsByCategoryId(UUID categoryId);
+
+    boolean existsBySubCategoryId(UUID subCategoryId);
+
+    /**
+     * Paged transaction search. Every filter is optional: a null argument
+     * disables that clause. Results are ordered/paginated via {@link Pageable}.
+     */
+    @Query("""
+            select t from Transaction t
+            where t.userId = :userId
+              and (:categoryId is null or t.categoryId = :categoryId)
+              and (:subCategoryId is null or t.subCategoryId = :subCategoryId)
+              and (:type is null or t.type = :type)
+              and (:from is null or t.transactionDate >= :from)
+              and (:to is null or t.transactionDate <= :to)
+            """)
+    Page<Transaction> search(
+            @Param("userId") UUID userId,
+            @Param("categoryId") UUID categoryId,
+            @Param("subCategoryId") UUID subCategoryId,
+            @Param("type") TransactionType type,
+            @Param("from") LocalDate from,
+            @Param("to") LocalDate to,
+            Pageable pageable);
+}

--- a/backend/src/main/java/com/expensetracker/repository/UserRepository.java
+++ b/backend/src/main/java/com/expensetracker/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package com.expensetracker.repository;
+
+import com.expensetracker.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/com/expensetracker/security/CurrentUser.java
+++ b/backend/src/main/java/com/expensetracker/security/CurrentUser.java
@@ -1,0 +1,20 @@
+package com.expensetracker.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Binds the authenticated user's id (UUID) to a controller method parameter,
+ * resolved from the Bearer access token by {@link CurrentUserArgumentResolver}.
+ *
+ * <pre>{@code
+ * @GetMapping("/categories")
+ * public ... list(@CurrentUser UUID userId) { ... }
+ * }</pre>
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/backend/src/main/java/com/expensetracker/security/CurrentUserArgumentResolver.java
+++ b/backend/src/main/java/com/expensetracker/security/CurrentUserArgumentResolver.java
@@ -1,0 +1,48 @@
+package com.expensetracker.security;
+
+import com.expensetracker.exception.AuthException;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.UUID;
+
+/**
+ * Resolves {@link CurrentUser}-annotated {@code UUID} parameters by validating
+ * the Bearer access token and returning the user id it was issued for.
+ */
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtService jwtService;
+
+    public CurrentUserArgumentResolver(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && parameter.getParameterType().equals(UUID.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        String header = webRequest.getHeader("Authorization");
+        if (!StringUtils.hasText(header) || !header.startsWith(BEARER_PREFIX)) {
+            throw new AuthException(HttpStatus.UNAUTHORIZED, "Missing or invalid Authorization header");
+        }
+        String token = header.substring(BEARER_PREFIX.length()).trim();
+        return jwtService.parseAccessToken(token);
+    }
+}

--- a/backend/src/main/java/com/expensetracker/security/JwtService.java
+++ b/backend/src/main/java/com/expensetracker/security/JwtService.java
@@ -1,0 +1,89 @@
+package com.expensetracker.security;
+
+import com.expensetracker.exception.AuthException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * Issues and validates HS256-signed JWTs. Two token types are produced:
+ * "access" (short-lived, sent as a Bearer header) and "refresh"
+ * (long-lived, exchanged at /auth/refresh). The token {@code type} claim
+ * prevents a refresh token from being accepted where an access token is
+ * required and vice versa.
+ */
+@Service
+public class JwtService {
+
+    private static final String CLAIM_TYPE = "type";
+    private static final String TYPE_ACCESS = "access";
+    private static final String TYPE_REFRESH = "refresh";
+
+    private final SecretKey key;
+    private final long accessExpirationMs;
+    private final long refreshExpirationMs;
+
+    public JwtService(
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.access-expiration-ms}") long accessExpirationMs,
+            @Value("${app.jwt.refresh-expiration-ms}") long refreshExpirationMs) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessExpirationMs = accessExpirationMs;
+        this.refreshExpirationMs = refreshExpirationMs;
+    }
+
+    public String generateAccessToken(UUID userId) {
+        return buildToken(userId, TYPE_ACCESS, accessExpirationMs);
+    }
+
+    public String generateRefreshToken(UUID userId) {
+        return buildToken(userId, TYPE_REFRESH, refreshExpirationMs);
+    }
+
+    /** Validates an access token and returns the user id it was issued for. */
+    public UUID parseAccessToken(String token) {
+        return parse(token, TYPE_ACCESS);
+    }
+
+    /** Validates a refresh token and returns the user id it was issued for. */
+    public UUID parseRefreshToken(String token) {
+        return parse(token, TYPE_REFRESH);
+    }
+
+    private String buildToken(UUID userId, String type, long ttlMs) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim(CLAIM_TYPE, type)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + ttlMs))
+                .signWith(key)
+                .compact();
+    }
+
+    private UUID parse(String token, String expectedType) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            if (!expectedType.equals(claims.get(CLAIM_TYPE, String.class))) {
+                throw new AuthException(HttpStatus.UNAUTHORIZED, "Invalid token type");
+            }
+            return UUID.fromString(claims.getSubject());
+        } catch (JwtException | IllegalArgumentException ex) {
+            throw new AuthException(HttpStatus.UNAUTHORIZED, "Invalid or expired token");
+        }
+    }
+}

--- a/backend/src/main/java/com/expensetracker/service/AuthService.java
+++ b/backend/src/main/java/com/expensetracker/service/AuthService.java
@@ -1,0 +1,91 @@
+package com.expensetracker.service;
+
+import com.expensetracker.dto.AuthResponse;
+import com.expensetracker.dto.LoginRequest;
+import com.expensetracker.dto.RegisterRequest;
+import com.expensetracker.dto.UserDto;
+import com.expensetracker.exception.AuthException;
+import com.expensetracker.model.User;
+import com.expensetracker.repository.UserRepository;
+import com.expensetracker.security.JwtService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Authentication business logic: registration, login, current-user lookup
+ * and token refresh. Stateless — tokens are self-contained JWTs, so logout
+ * is handled entirely on the client by discarding them.
+ */
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    public AuthService(UserRepository userRepository,
+                       PasswordEncoder passwordEncoder,
+                       JwtService jwtService) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtService = jwtService;
+    }
+
+    @Transactional
+    public AuthResponse register(RegisterRequest request) {
+        String email = request.getEmail().trim().toLowerCase();
+        if (userRepository.existsByEmail(email)) {
+            throw new AuthException(HttpStatus.CONFLICT, "Email is already registered");
+        }
+
+        User user = new User();
+        user.setEmail(email);
+        user.setPasswordHash(passwordEncoder.encode(request.getPassword()));
+        user.setFirstName(request.getFirstName().trim());
+        user.setLastName(request.getLastName().trim());
+        user.setCurrency("USD");
+        user.setTimezone("UTC");
+        user.setActive(true);
+        user.setEmailVerified(false);
+
+        User saved = userRepository.save(user);
+        return buildAuthResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public AuthResponse login(LoginRequest request) {
+        String email = request.getEmail().trim().toLowerCase();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthException(HttpStatus.UNAUTHORIZED, "Invalid email or password"));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPasswordHash())) {
+            throw new AuthException(HttpStatus.UNAUTHORIZED, "Invalid email or password");
+        }
+        return buildAuthResponse(user);
+    }
+
+    @Transactional(readOnly = true)
+    public UserDto getCurrentUser(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(HttpStatus.UNAUTHORIZED, "User not found"));
+        return UserDto.from(user);
+    }
+
+    @Transactional(readOnly = true)
+    public AuthResponse refresh(String refreshToken) {
+        UUID userId = jwtService.parseRefreshToken(refreshToken);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(HttpStatus.UNAUTHORIZED, "User not found"));
+        return buildAuthResponse(user);
+    }
+
+    private AuthResponse buildAuthResponse(User user) {
+        String accessToken = jwtService.generateAccessToken(user.getId());
+        String refreshToken = jwtService.generateRefreshToken(user.getId());
+        return new AuthResponse(UserDto.from(user), accessToken, refreshToken);
+    }
+}

--- a/backend/src/main/java/com/expensetracker/service/CategorySeeder.java
+++ b/backend/src/main/java/com/expensetracker/service/CategorySeeder.java
@@ -1,0 +1,68 @@
+package com.expensetracker.service;
+
+import com.expensetracker.model.Bucket;
+import com.expensetracker.model.Category;
+import com.expensetracker.model.CategoryKind;
+import com.expensetracker.model.SubCategory;
+import com.expensetracker.repository.CategoryRepository;
+import com.expensetracker.repository.SubCategoryRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Seeds a new user's default categories and sub-categories (50/30/20 layout).
+ * Seeds are user-owned and fully editable (isSystem=false) in P1.
+ */
+@Component
+public class CategorySeeder {
+
+    private record Seed(String name, CategoryKind kind, Bucket bucket, String color, List<String> subs) {}
+
+    private static final List<Seed> DEFAULTS = List.of(
+            new Seed("Income", CategoryKind.INCOME, Bucket.INCOME, "#22c55e",
+                    List.of("Salary", "Bonus", "Other Income")),
+            new Seed("Needs", CategoryKind.EXPENSE, Bucket.NEEDS, "#ef4444",
+                    List.of("Rent", "Groceries", "Utilities", "Transport", "Health")),
+            new Seed("Wants", CategoryKind.EXPENSE, Bucket.WANTS, "#f59e0b",
+                    List.of("Dining", "Entertainment", "Shopping")),
+            new Seed("Savings", CategoryKind.EXPENSE, Bucket.SAVINGS, "#3b82f6",
+                    List.of("Emergency Fund", "Investment")),
+            new Seed("Other", CategoryKind.EXPENSE, Bucket.OTHER, "#64748b",
+                    List.of())
+    );
+
+    private final CategoryRepository categoryRepository;
+    private final SubCategoryRepository subCategoryRepository;
+
+    public CategorySeeder(CategoryRepository categoryRepository,
+                          SubCategoryRepository subCategoryRepository) {
+        this.categoryRepository = categoryRepository;
+        this.subCategoryRepository = subCategoryRepository;
+    }
+
+    public void seedFor(UUID userId) {
+        int sortOrder = 0;
+        for (Seed seed : DEFAULTS) {
+            Category category = categoryRepository.save(Category.builder()
+                    .userId(userId)
+                    .name(seed.name())
+                    .kind(seed.kind())
+                    .bucket(seed.bucket())
+                    .color(seed.color())
+                    .system(false)
+                    .sortOrder(sortOrder++)
+                    .build());
+
+            for (String subName : seed.subs()) {
+                subCategoryRepository.save(SubCategory.builder()
+                        .categoryId(category.getId())
+                        .userId(userId)
+                        .name(subName)
+                        .system(false)
+                        .build());
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/expensetracker/service/CategoryService.java
+++ b/backend/src/main/java/com/expensetracker/service/CategoryService.java
@@ -1,0 +1,101 @@
+package com.expensetracker.service;
+
+import com.expensetracker.dto.CategoryDto;
+import com.expensetracker.dto.CategoryRequest;
+import com.expensetracker.exception.ApiException;
+import com.expensetracker.model.Category;
+import com.expensetracker.repository.CategoryRepository;
+import com.expensetracker.repository.SubCategoryRepository;
+import com.expensetracker.repository.TransactionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final SubCategoryRepository subCategoryRepository;
+    private final TransactionRepository transactionRepository;
+    private final CategorySeeder categorySeeder;
+
+    public CategoryService(CategoryRepository categoryRepository,
+                           SubCategoryRepository subCategoryRepository,
+                           TransactionRepository transactionRepository,
+                           CategorySeeder categorySeeder) {
+        this.categoryRepository = categoryRepository;
+        this.subCategoryRepository = subCategoryRepository;
+        this.transactionRepository = transactionRepository;
+        this.categorySeeder = categorySeeder;
+    }
+
+    /** Lists the user's categories, seeding sensible defaults on first access. */
+    @Transactional
+    public List<CategoryDto> list(UUID userId) {
+        if (categoryRepository.countByUserId(userId) == 0) {
+            categorySeeder.seedFor(userId);
+        }
+        return categoryRepository.findByUserIdOrderBySortOrderAscNameAsc(userId).stream()
+                .map(CategoryDto::from)
+                .toList();
+    }
+
+    @Transactional
+    public CategoryDto create(UUID userId, CategoryRequest request) {
+        String name = request.getName().trim();
+        if (categoryRepository.existsByUserIdAndNameIgnoreCase(userId, name)) {
+            throw ApiException.conflict("A category with this name already exists");
+        }
+        int nextSort = (int) categoryRepository.countByUserId(userId);
+        Category saved = categoryRepository.save(Category.builder()
+                .userId(userId)
+                .name(name)
+                .kind(request.getKind())
+                .bucket(request.getBucket())
+                .icon(request.getIcon())
+                .color(request.getColor())
+                .system(false)
+                .sortOrder(nextSort)
+                .build());
+        return CategoryDto.from(saved);
+    }
+
+    @Transactional
+    public CategoryDto update(UUID userId, UUID id, CategoryRequest request) {
+        Category category = requireOwned(userId, id);
+        if (category.isSystem()) {
+            throw ApiException.forbidden("System categories cannot be modified");
+        }
+        String name = request.getName().trim();
+        if (!name.equalsIgnoreCase(category.getName())
+                && categoryRepository.existsByUserIdAndNameIgnoreCase(userId, name)) {
+            throw ApiException.conflict("A category with this name already exists");
+        }
+        category.setName(name);
+        category.setKind(request.getKind());
+        category.setBucket(request.getBucket());
+        category.setIcon(request.getIcon());
+        category.setColor(request.getColor());
+        return CategoryDto.from(categoryRepository.save(category));
+    }
+
+    @Transactional
+    public void delete(UUID userId, UUID id) {
+        Category category = requireOwned(userId, id);
+        if (category.isSystem()) {
+            throw ApiException.forbidden("System categories cannot be deleted");
+        }
+        if (transactionRepository.existsByCategoryId(id)) {
+            throw ApiException.conflict("Category has transactions; reassign or delete them first");
+        }
+        subCategoryRepository.deleteAll(subCategoryRepository.findByCategoryIdOrderByNameAsc(id));
+        categoryRepository.delete(category);
+    }
+
+    private Category requireOwned(UUID userId, UUID id) {
+        return categoryRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> ApiException.notFound("Category not found"));
+    }
+}

--- a/backend/src/main/java/com/expensetracker/service/SubCategoryService.java
+++ b/backend/src/main/java/com/expensetracker/service/SubCategoryService.java
@@ -1,0 +1,99 @@
+package com.expensetracker.service;
+
+import com.expensetracker.dto.SubCategoryDto;
+import com.expensetracker.dto.SubCategoryRequest;
+import com.expensetracker.exception.ApiException;
+import com.expensetracker.model.SubCategory;
+import com.expensetracker.repository.CategoryRepository;
+import com.expensetracker.repository.SubCategoryRepository;
+import com.expensetracker.repository.TransactionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class SubCategoryService {
+
+    private final SubCategoryRepository subCategoryRepository;
+    private final CategoryRepository categoryRepository;
+    private final TransactionRepository transactionRepository;
+
+    public SubCategoryService(SubCategoryRepository subCategoryRepository,
+                              CategoryRepository categoryRepository,
+                              TransactionRepository transactionRepository) {
+        this.subCategoryRepository = subCategoryRepository;
+        this.categoryRepository = categoryRepository;
+        this.transactionRepository = transactionRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<SubCategoryDto> list(UUID userId, UUID categoryId) {
+        List<SubCategory> subs = (categoryId != null)
+                ? subCategoryRepository.findByCategoryIdOrderByNameAsc(requireOwnedCategory(userId, categoryId))
+                : subCategoryRepository.findByUserIdOrderByNameAsc(userId);
+        return subs.stream().map(SubCategoryDto::from).toList();
+    }
+
+    @Transactional
+    public SubCategoryDto create(UUID userId, SubCategoryRequest request) {
+        UUID categoryId = requireOwnedCategory(userId, request.getCategoryId());
+        String name = request.getName().trim();
+        if (subCategoryRepository.existsByCategoryIdAndNameIgnoreCase(categoryId, name)) {
+            throw ApiException.conflict("A sub-category with this name already exists in this category");
+        }
+        SubCategory saved = subCategoryRepository.save(SubCategory.builder()
+                .categoryId(categoryId)
+                .userId(userId)
+                .name(name)
+                .icon(request.getIcon())
+                .color(request.getColor())
+                .monthlyLimit(request.getMonthlyLimit())
+                .system(false)
+                .build());
+        return SubCategoryDto.from(saved);
+    }
+
+    @Transactional
+    public SubCategoryDto update(UUID userId, UUID id, SubCategoryRequest request) {
+        SubCategory sub = requireOwned(userId, id);
+        UUID targetCategoryId = requireOwnedCategory(userId, request.getCategoryId());
+        String name = request.getName().trim();
+
+        boolean nameOrCategoryChanged = !targetCategoryId.equals(sub.getCategoryId())
+                || !name.equalsIgnoreCase(sub.getName());
+        if (nameOrCategoryChanged
+                && subCategoryRepository.existsByCategoryIdAndNameIgnoreCase(targetCategoryId, name)) {
+            throw ApiException.conflict("A sub-category with this name already exists in this category");
+        }
+
+        sub.setCategoryId(targetCategoryId);
+        sub.setName(name);
+        sub.setIcon(request.getIcon());
+        sub.setColor(request.getColor());
+        sub.setMonthlyLimit(request.getMonthlyLimit());
+        return SubCategoryDto.from(subCategoryRepository.save(sub));
+    }
+
+    @Transactional
+    public void delete(UUID userId, UUID id) {
+        SubCategory sub = requireOwned(userId, id);
+        if (transactionRepository.existsBySubCategoryId(id)) {
+            throw ApiException.conflict("Sub-category has transactions; reassign or delete them first");
+        }
+        subCategoryRepository.delete(sub);
+    }
+
+    private SubCategory requireOwned(UUID userId, UUID id) {
+        return subCategoryRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> ApiException.notFound("Sub-category not found"));
+    }
+
+    /** Verifies the category exists and belongs to the user; returns its id. */
+    private UUID requireOwnedCategory(UUID userId, UUID categoryId) {
+        return categoryRepository.findByIdAndUserId(categoryId, userId)
+                .orElseThrow(() -> ApiException.notFound("Category not found"))
+                .getId();
+    }
+}

--- a/backend/src/main/java/com/expensetracker/service/TransactionService.java
+++ b/backend/src/main/java/com/expensetracker/service/TransactionService.java
@@ -1,0 +1,119 @@
+package com.expensetracker.service;
+
+import com.expensetracker.dto.TransactionDto;
+import com.expensetracker.dto.TransactionRequest;
+import com.expensetracker.exception.ApiException;
+import com.expensetracker.model.SourceType;
+import com.expensetracker.model.SubCategory;
+import com.expensetracker.model.Transaction;
+import com.expensetracker.model.TransactionType;
+import com.expensetracker.repository.CategoryRepository;
+import com.expensetracker.repository.SubCategoryRepository;
+import com.expensetracker.repository.TransactionRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class TransactionService {
+
+    private static final Sort DEFAULT_SORT =
+            Sort.by(Sort.Direction.DESC, "transactionDate", "createdAt");
+
+    private final TransactionRepository transactionRepository;
+    private final CategoryRepository categoryRepository;
+    private final SubCategoryRepository subCategoryRepository;
+
+    public TransactionService(TransactionRepository transactionRepository,
+                              CategoryRepository categoryRepository,
+                              SubCategoryRepository subCategoryRepository) {
+        this.transactionRepository = transactionRepository;
+        this.categoryRepository = categoryRepository;
+        this.subCategoryRepository = subCategoryRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<TransactionDto> list(UUID userId, UUID categoryId, UUID subCategoryId,
+                                     TransactionType type, LocalDate from, LocalDate to) {
+        return transactionRepository
+                .search(userId, categoryId, subCategoryId, type, from, to, Pageable.unpaged(DEFAULT_SORT))
+                .stream()
+                .map(TransactionDto::from)
+                .toList();
+    }
+
+    @Transactional
+    public TransactionDto create(UUID userId, TransactionRequest request) {
+        validateCategoryAndSubCategory(userId, request.getCategoryId(), request.getSubCategoryId());
+        Transaction saved = transactionRepository.save(Transaction.builder()
+                .userId(userId)
+                .name(request.getName().trim())
+                .amount(request.getAmount())
+                .currency(normaliseCurrency(request.getCurrency()))
+                .categoryId(request.getCategoryId())
+                .subCategoryId(request.getSubCategoryId())
+                .type(request.getType())
+                .transactionDate(request.getTransactionDate())
+                .note(request.getNote())
+                .sourceType(SourceType.MANUAL)
+                .build());
+        return TransactionDto.from(saved);
+    }
+
+    @Transactional
+    public TransactionDto update(UUID userId, UUID id, TransactionRequest request) {
+        Transaction tx = transactionRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> ApiException.notFound("Transaction not found"));
+        validateCategoryAndSubCategory(userId, request.getCategoryId(), request.getSubCategoryId());
+        tx.setName(request.getName().trim());
+        tx.setAmount(request.getAmount());
+        tx.setCurrency(normaliseCurrency(request.getCurrency()));
+        tx.setCategoryId(request.getCategoryId());
+        tx.setSubCategoryId(request.getSubCategoryId());
+        tx.setType(request.getType());
+        tx.setTransactionDate(request.getTransactionDate());
+        tx.setNote(request.getNote());
+        return TransactionDto.from(transactionRepository.save(tx));
+    }
+
+    @Transactional
+    public void delete(UUID userId, UUID id) {
+        Transaction tx = transactionRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> ApiException.notFound("Transaction not found"));
+        transactionRepository.delete(tx);
+    }
+
+    /**
+     * Enforces the core entry rule: the category must be owned by the user,
+     * a sub-category is required when the category has any, and the chosen
+     * sub-category must belong to that category.
+     */
+    private void validateCategoryAndSubCategory(UUID userId, UUID categoryId, UUID subCategoryId) {
+        categoryRepository.findByIdAndUserId(categoryId, userId)
+                .orElseThrow(() -> ApiException.notFound("Category not found"));
+
+        boolean categoryHasSubs = subCategoryRepository.countByCategoryId(categoryId) > 0;
+
+        if (subCategoryId == null) {
+            if (categoryHasSubs) {
+                throw ApiException.badRequest("A sub-category is required for this category");
+            }
+            return;
+        }
+
+        SubCategory sub = subCategoryRepository.findByIdAndUserId(subCategoryId, userId)
+                .orElseThrow(() -> ApiException.notFound("Sub-category not found"));
+        if (!sub.getCategoryId().equals(categoryId)) {
+            throw ApiException.badRequest("Sub-category does not belong to the selected category");
+        }
+    }
+
+    private String normaliseCurrency(String currency) {
+        return (currency == null || currency.isBlank()) ? "USD" : currency.trim().toUpperCase();
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,8 +1,37 @@
 # Server Configuration
 server.port=8080
 
+# ================================================================
+# JWT / Auth
+# ================================================================
+# Secret is read from the APP_JWT_SECRET env var in real deployments;
+# the fallback below is DEV-ONLY and must be overridden in production.
+# HS256 requires at least 32 bytes (256 bits).
+app.jwt.secret=${APP_JWT_SECRET:dev-only-change-me-expense-tracker-jwt-signing-key-please-override-in-prod}
+app.jwt.access-expiration-ms=3600000
+app.jwt.refresh-expiration-ms=604800000
+
+# ================================================================
+# CORS — origins allowed to call /api/**
+# ================================================================
+app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}
+
+# Serialize java.time values (Instant) as ISO-8601 strings, not arrays
+spring.jackson.serialization.write-dates-as-timestamps=false
+
 # H2 Database Configuration (for development)
-spring.datasource.url=jdbc:h2:mem:expensedb
+# File-based storage so data SURVIVES restarts. The DB lives in
+# ./data/expensedb.mv.db relative to the backend working directory
+# (i.e. backend/data/ when running `mvn spring-boot:run`). The
+# embedded /h2-console runs in the same JVM, so no AUTO_SERVER flag
+# is needed. (Note: H2 rejects AUTO_SERVER combined with
+# DB_CLOSE_ON_EXIT, so we keep the URL plain aside from WRITE_DELAY.)
+#
+# WRITE_DELAY=0 flushes every committed transaction to disk
+# immediately, so data survives even an ungraceful shutdown
+# (IDE "stop", kill, crash) — not just a clean Ctrl+C. Negligible
+# overhead for a single-user dev database.
+spring.datasource.url=jdbc:h2:file:./data/expensedb;WRITE_DELAY=0
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,21 @@
+# Test-only overrides
+# ================================================================
+# Tests must NOT touch the file-based dev database. This overlay
+# switches the datasource back to a throwaway in-memory H2 so each
+# test run starts clean and never writes to backend/data/.
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+
+# A test application.properties fully SHADOWS the main one (Spring
+# loads only the first application.properties on the classpath), so
+# every app.* placeholder the beans need must be repeated here.
+# JwtService -> secret + both expirations; WebConfig -> CORS origins.
+app.jwt.secret=test-only-secret-key-at-least-32-bytes-long-for-hs256-signing
+app.jwt.access-expiration-ms=3600000
+app.jwt.refresh-expiration-ms=604800000
+app.cors.allowed-origins=http://localhost:5173

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -18,6 +18,10 @@ import type {
   UpdateGoalRequest,
   Category,
   CreateCategoryRequest,
+  UpdateCategoryRequest,
+  SubCategory,
+  CreateSubCategoryRequest,
+  UpdateSubCategoryRequest,
   Investment,
   CreateInvestmentRequest,
   UpdateInvestmentRequest,
@@ -374,10 +378,66 @@ export const categoriesApi = {
     return data.data;
   },
 
+  update: async (id: string, categoryData: UpdateCategoryRequest): Promise<Category> => {
+    const { data } = await apiClient.put<ApiResponse<Category>>(
+      `/categories/${id}`,
+      categoryData
+    );
+    if (!data.success || !data.data) {
+      throw new Error(data.error || 'Failed to update category');
+    }
+    return data.data;
+  },
+
   delete: async (id: string): Promise<void> => {
     const { data } = await apiClient.delete<ApiResponse<void>>(`/categories/${id}`);
     if (!data.success) {
       throw new Error(data.error || 'Failed to delete category');
+    }
+  },
+};
+
+// ============================================
+// Sub-categories API
+// ============================================
+
+export const subCategoriesApi = {
+  getAll: async (categoryId?: string): Promise<SubCategory[]> => {
+    const { data } = await apiClient.get<ApiResponse<SubCategory[]>>('/subcategories', {
+      params: categoryId ? { categoryId } : undefined,
+    });
+    if (!data.success || !data.data) {
+      throw new Error(data.error || 'Failed to fetch sub-categories');
+    }
+    return data.data;
+  },
+
+  create: async (subCategoryData: CreateSubCategoryRequest): Promise<SubCategory> => {
+    const { data } = await apiClient.post<ApiResponse<SubCategory>>(
+      '/subcategories',
+      subCategoryData
+    );
+    if (!data.success || !data.data) {
+      throw new Error(data.error || 'Failed to create sub-category');
+    }
+    return data.data;
+  },
+
+  update: async (id: string, subCategoryData: UpdateSubCategoryRequest): Promise<SubCategory> => {
+    const { data } = await apiClient.put<ApiResponse<SubCategory>>(
+      `/subcategories/${id}`,
+      subCategoryData
+    );
+    if (!data.success || !data.data) {
+      throw new Error(data.error || 'Failed to update sub-category');
+    }
+    return data.data;
+  },
+
+  delete: async (id: string): Promise<void> => {
+    const { data } = await apiClient.delete<ApiResponse<void>>(`/subcategories/${id}`);
+    if (!data.success) {
+      throw new Error(data.error || 'Failed to delete sub-category');
     }
   },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -30,31 +30,39 @@ export interface Account {
 
 export interface Category {
   id: string;
-  userId: string | null;
   name: string;
-  type: TransactionType;
+  kind: CategoryKind;
+  bucket: Bucket;
   icon: string | null;
   color: string | null;
-  parentId: string | null;
   isSystem: boolean;
-  createdAt: string;
+  sortOrder: number;
+}
+
+export interface SubCategory {
+  id: string;
+  categoryId: string;
+  name: string;
+  icon: string | null;
+  color: string | null;
+  monthlyLimit: number | null;
+  isSystem: boolean;
 }
 
 export interface Transaction {
   id: string;
-  userId: string;
-  accountId: string;
-  categoryId: string | null;
-  type: TransactionType;
+  name: string;
   amount: number;
   currency: string;
-  description: string | null;
+  categoryId: string;
+  subCategoryId: string | null;
+  type: TransactionType;
   transactionDate: string;
+  note: string | null;
+  sourceType: SourceType;
+  installmentNo: number | null;
   createdAt: string;
   updatedAt: string;
-  // Populated fields
-  account?: Account;
-  category?: Category;
 }
 
 export interface Goal {
@@ -101,10 +109,13 @@ export type AccountType =
   | 'investment'
   | 'cash';
 
-export type TransactionType =
-  | 'income'
-  | 'expense'
-  | 'transfer';
+export type TransactionType = 'INCOME' | 'EXPENSE';
+
+export type CategoryKind = 'INCOME' | 'EXPENSE';
+
+export type Bucket = 'INCOME' | 'NEEDS' | 'WANTS' | 'SAVINGS' | 'OTHER';
+
+export type SourceType = 'MANUAL' | 'RECURRING' | 'INSTALLMENT';
 
 export type GoalStatus =
   | 'active'
@@ -161,13 +172,14 @@ export interface AuthResponse {
 
 // Transactions
 export interface CreateTransactionRequest {
-  accountId: string;
-  categoryId?: string;
-  type: TransactionType;
+  name: string;
   amount: number;
   currency?: string;
-  description?: string;
+  categoryId: string;
+  subCategoryId?: string | null;
+  type: TransactionType;
   transactionDate: string;
+  note?: string | null;
 }
 
 export interface UpdateTransactionRequest extends Partial<CreateTransactionRequest> {
@@ -175,13 +187,11 @@ export interface UpdateTransactionRequest extends Partial<CreateTransactionReque
 }
 
 export interface TransactionFilters {
-  accountId?: string;
   categoryId?: string;
+  subCategoryId?: string;
   type?: TransactionType;
-  startDate?: string;
-  endDate?: string;
-  minAmount?: number;
-  maxAmount?: number;
+  from?: string;
+  to?: string;
 }
 
 // Accounts
@@ -212,11 +222,24 @@ export interface UpdateGoalRequest extends Partial<CreateGoalRequest> {
 // Categories
 export interface CreateCategoryRequest {
   name: string;
-  type: TransactionType;
-  icon?: string;
-  color?: string;
-  parentId?: string;
+  kind: CategoryKind;
+  bucket: Bucket;
+  icon?: string | null;
+  color?: string | null;
 }
+
+export type UpdateCategoryRequest = CreateCategoryRequest;
+
+// Sub-categories
+export interface CreateSubCategoryRequest {
+  categoryId: string;
+  name: string;
+  icon?: string | null;
+  color?: string | null;
+  monthlyLimit?: number | null;
+}
+
+export type UpdateSubCategoryRequest = CreateSubCategoryRequest;
 
 // Investments
 export interface CreateInvestmentRequest {

--- a/plan/FEATURE_CATEGORIES_TRANSACTIONS.md
+++ b/plan/FEATURE_CATEGORIES_TRANSACTIONS.md
@@ -1,0 +1,235 @@
+# Feature Plan — Categorized Transactions, Budgets, Recurring & Installments
+
+> Status: **Draft for review** · Owner: Meryem · Created: 2026-07-14
+> Scope: Extend the Expense Tracker beyond the existing balance overview with a
+> full category/sub-category system, per-sub-category spending limits, a rich
+> transaction entry flow, and support for recurring (periodic) and installment
+> (*taksitli*) payments so future months are generated automatically.
+
+---
+
+## 1. Goal (from request)
+
+When a user signs up and starts entering money movements, they should be able to:
+
+1. Pick a **top-level category**: Income, Needs, Wants, Savings (Balance overview already exists).
+2. Enter a **transaction name** and **amount**.
+3. If the chosen category has **sub-categories** (e.g. Needs → *Groceries*), pick one.
+4. Sub-categories may carry an optional **spending limit** (monthly cap).
+5. Enter the **date** the money was spent.
+6. Mark the entry as **recurring (periodic)** *or* **installment (*taksitli*)** so it is
+   **created automatically in the following months** — the user must not have to
+   re-enter it every month.
+7. See it all reflected in the **overview** against budgeting **rules for finance**.
+
+---
+
+## 2. Assumptions & open questions
+
+These drive the task breakdown. Please confirm or correct — cheap to change now.
+
+| # | Assumption | If wrong… |
+|---|------------|-----------|
+| A1 | **"Rules for finance" = 50/30/20 budget rule**: target % for Needs (50) / Wants (30) / Savings (20), configurable per user. | Replace Epic 6 with the intended rule engine. |
+| A2 | Top-level categories are **system-seeded** (Income, Needs, Wants, Savings, Other) but the user can **add their own** too. | If fixed-only, drop the category CRUD FE/BE tasks. |
+| A3 | **"Expenses"** in the request is the umbrella term for Needs+Wants+Other, not a separate sibling bucket. Modeled as an `Other/General` expense category. | Add a distinct top-level "Expenses" category. |
+| A4 | Sub-category limits are **monthly** and reset each calendar month. | Support weekly/custom windows. |
+| A5 | **Installment** = a fixed total split into *N equal monthly* charges starting on a date (e.g. 12.000 ₺ / 12 = 1.000 ₺ x 12). | Support variable amounts / other intervals. |
+| A6 | **Recurring** occurrences are **materialized** (real Transaction rows generated on a schedule + catch-up at login), not computed on the fly. | Switch to virtual/derived occurrences. |
+| A7 | Currency, auth and the balance overview from Phase 1 stay as-is; this feature plugs into them. | — |
+
+---
+
+## 3. Proposed data model
+
+```
+Category            (top-level bucket)
+  id, userId(null = system), name, kind(INCOME|EXPENSE),
+  bucket(NEEDS|WANTS|SAVINGS|INCOME|OTHER), icon, color, isSystem, sortOrder
+
+SubCategory         (belongs to a Category)
+  id, categoryId, userId, name, icon, color,
+  monthlyLimit(nullable, >0), isSystem
+
+Transaction         (extends the existing entity)
+  id, userId, name, amount, currency,
+  categoryId, subCategoryId(nullable), type(INCOME|EXPENSE),
+  transactionDate, note,
+  sourceType(MANUAL|RECURRING|INSTALLMENT),
+  recurringRuleId(nullable), installmentPlanId(nullable), installmentNo(nullable)
+
+RecurringRule
+  id, userId, name, amount, categoryId, subCategoryId,
+  frequency(WEEKLY|MONTHLY|YEARLY), interval(int>=1),
+  startDate, endDate(nullable), nextRunDate, active
+
+InstallmentPlan
+  id, userId, name, totalAmount, installmentCount,
+  categoryId, subCategoryId, startDate, perInstallmentAmount, active
+
+BudgetRule          ("rules for finance", 50/30/20)
+  id, userId, needsPct, wantsPct, savingsPct   (must sum to 100)
+```
+
+**API surface (Spring Boot, all under `/api`, all wrapped in the existing
+`ApiResponse<T>` envelope):**
+
+```
+GET/POST/PUT/DELETE  /categories                 /categories/{id}
+GET/POST/PUT/DELETE  /subcategories              /subcategories/{id}
+GET                  /subcategories/{id}/spending?month=YYYY-MM
+GET/POST/PUT/DELETE  /transactions               /transactions/{id}
+GET                  /transactions?categoryId=&subCategoryId=&from=&to=&type=
+GET/POST/PUT/DELETE  /recurring-rules            /recurring-rules/{id}
+POST                 /recurring-rules/run        (materialize due occurrences)
+GET/POST/DELETE      /installment-plans          /installment-plans/{id}
+GET/PUT              /budget-rule
+GET                  /overview?month=YYYY-MM      (buckets vs target, limits, upcoming)
+```
+
+---
+
+## 4. Epics & tasks
+
+Priority: **P1** = core / do first · **P2** = important · **P3** = polish.
+IDs: `ET-BE-xx` (backend, Spring Boot) · `ET-FE-xx` (frontend, React/TS).
+
+### Epic 1 — Category & sub-category foundation
+
+- **ET-BE-01 · Category & SubCategory entities + persistence** — P1
+  Create `Category`, `SubCategory` JPA entities, repositories, DB schema.
+  *AC:* tables created on H2/MySQL; unique (userId,name) per level; cascade rules defined; unit test for repository CRUD.
+- **ET-BE-02 · Seed default categories & sub-categories** — P1 · dep: ET-BE-01
+  Seed on first run: Income; Needs (Rent, Groceries, Utilities, Transport, Health); Wants (Dining, Entertainment, Shopping); Savings (Emergency fund, Investment); Other.
+  *AC:* new user gets system categories; seeding is idempotent.
+- **ET-BE-03 · Category CRUD API** — P1 · dep: ET-BE-01
+  `GET/POST/PUT/DELETE /categories`, scoped to current user + system read-only.
+  *AC:* user cannot edit/delete system categories; validation errors return `ApiResponse.fail`; 80% test coverage on service.
+- **ET-BE-04 · SubCategory CRUD API** — P1 · dep: ET-BE-01
+  `GET/POST/PUT/DELETE /subcategories`, filter by `categoryId`.
+  *AC:* sub-category must belong to a category owned/visible to user; tests.
+- **ET-FE-01 · Category/SubCategory types + API client** — P1
+  Extend `types/index.ts` and `services/api.ts` (`categoriesApi` already stubbed; add `subCategoriesApi`).
+  *AC:* typed client methods; React Query hooks; no `any`.
+- **ET-FE-02 · Category management screen** — P2 · dep: ET-FE-01, ET-BE-03
+  List categories grouped by bucket; add/edit/delete user categories; icon+color picker.
+  *AC:* optimistic updates; system categories shown read-only.
+- **ET-FE-03 · Sub-category management (within a category)** — P2 · dep: ET-FE-02, ET-BE-04
+  Expand a category to manage its sub-categories.
+  *AC:* create/edit/delete; empty-state guidance.
+
+### Epic 2 — Sub-category spending limits (budgets)
+
+- **ET-BE-05 · `monthlyLimit` on SubCategory + validation** — P1 · dep: ET-BE-01
+  Add nullable positive `monthlyLimit`; expose in sub-category API.
+  *AC:* reject `<= 0`; null = no limit; migration safe.
+- **ET-BE-06 · Spending-vs-limit endpoint** — P2 · dep: ET-BE-05, ET-BE-08
+  `GET /subcategories/{id}/spending?month=YYYY-MM` → {spent, limit, remaining, pct, overLimit}.
+  *AC:* sums only that user's expense transactions in the month; tested with boundary dates.
+- **ET-FE-04 · Limit field in sub-category form** — P2 · dep: ET-FE-03, ET-BE-05
+  Optional "Monthly limit" input.
+  *AC:* zod validation (>0 or empty); persists.
+- **ET-FE-05 · Limit progress + over-limit warning** — P2 · dep: ET-FE-04, ET-BE-06
+  Progress bar spent/limit; red state + warning when exceeded.
+  *AC:* accessible colors; shows "no limit set" when null.
+
+### Epic 3 — Transaction entry with category & sub-category
+
+- **ET-BE-07 · Extend Transaction entity** — P1 · dep: ET-BE-01
+  Add `name`, `subCategoryId`, `sourceType`, `recurringRuleId`, `installmentPlanId`, `installmentNo`; keep `amount`, `categoryId`, `transactionDate`, `type`.
+  *AC:* migration; existing rows unaffected; entity tests.
+- **ET-BE-08 · Create/Update transaction API + rules** — P1 · dep: ET-BE-07, ET-BE-04
+  Validate: name & amount required; category required; **sub-category required when the category has sub-categories**; sub-category must belong to the category; ownership enforced.
+  *AC:* 400 with clear message on rule violations; happy-path + rule tests.
+- **ET-BE-09 · List/filter transactions** — P1 · dep: ET-BE-08
+  `GET /transactions` with filters (categoryId, subCategoryId, from, to, type) + pagination.
+  *AC:* filters composable; paginated envelope; tests.
+- **ET-FE-06 · Transaction entry form** — P1 · dep: ET-FE-01, ET-BE-08
+  Fields: name, amount, category select, **dependent** sub-category select, date picker.
+  *AC:* zod schema; server errors surfaced; disabled submit while invalid.
+- **ET-FE-07 · Dependent sub-category dropdown** — P1 · dep: ET-FE-06
+  Sub-category options load from the selected category; required only when options exist.
+  *AC:* clears sub-category when category changes; loading/empty handled.
+- **ET-FE-08 · Transaction list + edit/delete** — P2 · dep: ET-FE-06, ET-BE-09
+  Filterable list; edit reopens the form; delete with confirm.
+  *AC:* optimistic update; filter by category/sub-category/date.
+
+### Epic 4 — Recurring (periodic) expenses
+
+- **ET-BE-10 · RecurringRule model + API** — P1 · dep: ET-BE-07
+  Entity + `GET/POST/PUT/DELETE /recurring-rules` (frequency, interval, start/end, template amount/category/sub-category).
+  *AC:* validation (interval>=1, endDate>startDate); tests.
+- **ET-BE-11 · Occurrence generation (idempotent)** — P1 · dep: ET-BE-10
+  Given "now", generate all due Transactions from active rules up to today; never double-generate (track `nextRunDate` / occurrence key).
+  *AC:* running twice creates each occurrence once; unit tests over month boundaries & leap cases.
+- **ET-BE-12 · Scheduler + login catch-up** — P2 · dep: ET-BE-11
+  `@Scheduled` daily job **and** a catch-up call on login/app-load (`POST /recurring-rules/run`) so a user who was away still gets past months filled.
+  *AC:* documented trigger; safe to call repeatedly.
+- **ET-FE-09 · "Repeat" controls in the form** — P1 · dep: ET-FE-06, ET-BE-10
+  Toggle → frequency (weekly/monthly/yearly), interval, optional end date.
+  *AC:* preview text ("Every month until …"); validation.
+- **ET-FE-10 · Recurring rules management** — P2 · dep: ET-FE-09, ET-BE-12
+  List active rules, show next run, pause/stop, delete.
+  *AC:* pausing stops future generation; past rows untouched.
+
+### Epic 5 — Installment payments (*taksitli ödeme*)
+
+- **ET-BE-13 · InstallmentPlan model + generation** — P1 · dep: ET-BE-07
+  On create: split `totalAmount` into `installmentCount` equal monthly Transactions (rounding remainder into the last one), linked via `installmentPlanId` + `installmentNo`.
+  *AC:* sum of installments == total (to the cent); N rows across N months; tests.
+- **ET-BE-14 · Installment plan API** — P2 · dep: ET-BE-13
+  `GET/POST/DELETE /installment-plans`; show paid vs remaining; delete cancels **future** unpaid installments only.
+  *AC:* deleting keeps already-past charges; tests.
+- **ET-FE-11 · Installment option in the form** — P1 · dep: ET-FE-06, ET-BE-13
+  Inputs: total, count → live preview of per-month amount and schedule.
+  *AC:* preview updates on change; validation (count>=2).
+- **ET-FE-12 · Installment plan detail** — P3 · dep: ET-FE-11, ET-BE-14
+  Paid/remaining, upcoming months, cancel remaining.
+  *AC:* clear paid vs upcoming states.
+
+### Epic 6 — Budget rules (50/30/20) & overview integration
+
+- **ET-BE-15 · BudgetRule config API** — P2
+  `GET/PUT /budget-rule` (needsPct+wantsPct+savingsPct == 100), default 50/30/20.
+  *AC:* rejects sums != 100; per-user; tests.
+- **ET-BE-16 · Overview/summary endpoint** — P1 · dep: ET-BE-09, ET-BE-15
+  `GET /overview?month=` → income, spend per bucket, actual-vs-target, savings rate, sub-category limit statuses, upcoming recurring/installments.
+  *AC:* one call powers the dashboard; tested aggregation.
+- **ET-FE-13 · "Rules for finance" settings** — P3 · dep: ET-BE-15
+  Edit 50/30/20 targets with a sum=100 guard.
+  *AC:* validation; persists.
+- **ET-FE-14 · Overview widgets** — P2 · dep: ET-FE-01, ET-BE-16
+  Bucket breakdown vs target, sub-category limit statuses, upcoming recurring/installment list on the dashboard.
+  *AC:* uses `/overview`; animated (Recharts/Framer already in stack).
+
+### Epic 7 — Cross-cutting quality
+
+- **ET-BE-17 · Backend tests to 80%** — P2
+  Service + controller + repository tests across the new modules (JUnit 5).
+  *AC:* JaCoCo ratio raised toward 0.80 per `pom.xml` plan.
+- **ET-FE-15 · Frontend tests** — P2
+  Vitest for form/validation + Playwright E2E for "add categorized transaction" and "create recurring".
+  *AC:* critical flows green in CI.
+- **ET-DOC-01 · Update README & API docs** — P3
+  Document new endpoints, data model, and the recurring/installment behavior.
+  *AC:* README reflects the shipped feature.
+
+---
+
+## 5. Suggested delivery order
+
+1. **Foundation:** ET-BE-01 → 02 → 07 → 03/04, ET-FE-01.
+2. **Core entry:** ET-BE-08 → 09, ET-FE-06 → 07 → 08.
+3. **Limits:** ET-BE-05 → 06, ET-FE-04 → 05.
+4. **Recurring:** ET-BE-10 → 11 → 12, ET-FE-09 → 10.
+5. **Installments:** ET-BE-13 → 14, ET-FE-11 → 12.
+6. **Rules & overview:** ET-BE-15 → 16, ET-FE-13 → 14.
+7. **Quality:** ET-BE-17, ET-FE-15, ET-DOC-01.
+
+---
+
+## 6. Export to task-manager
+
+These tasks are also exported for the **task-manager** app (`Projeler/task-manager`) as
+an importable file + loader script — see
+[`task-manager/seeds/README.md`](../../task-manager/seeds/README.md).


### PR DESCRIPTION
## Summary

The \`Dependency Scan\` job has been failing on every backend-touching PR with this stack trace:

\`\`\`
UpdateException: Error updating the NVD Data
  InvalidFormatException: Cannot deserialize value of type
    \`java.time.ZonedDateTime\` from String \"2026-04-15T15:25:08.976199400Z\"
  DateTimeParseException: unparsed text found at index 23
\`\`\`

Root cause is **upstream in `dependency-check-maven` 12.2.x**: its bundled `openvulnerability-client` can't parse the nanosecond-precision (9 fractional-second digits) timestamps the NVD API now returns. The parser stops at millisecond precision; everything after position 23 in the string trips it.

This is not project code being wrong — we just hit it because the workflow invoked the plugin without a version pin, so CI resolved the latest release and that release was broken.

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [x] CI/CD or configuration change

## Two-part fix in one workflow step

### Part A — Pin to `12.1.3`
Last known-good release before the regression. Pinning at the goal level (`org.owasp:dependency-check-maven:12.1.3:check`) keeps this contained to the workflow file; no `pom.xml` changes, no `pluginManagement` refactor.

### Part B — Pass NVD API key from repo secrets
The authenticated NVD tier has:
- Higher rate limits (~50 req / 30s vs ~6 req / 30s anonymous)
- Faster cold-cache updates (~2 min vs ~30 min)
- A different serverside path that sidesteps the timestamp regression entirely

\`NVD_API_KEY\` is wired through the workflow via \`env:\` and passed to mvn as \`-DnvdApiKey=\"\${NVD_API_KEY:-}\"\`. The shell default expansion is the safety net: **if the secret is missing** (forks, first-time PRs), the flag is empty and the plugin transparently falls back to anonymous mode. No crash, no missing-secret warning, the workflow still works for everyone.

## Diff

\`\`\`diff
       - name: Backend - OWASP Dependency Check
+        # Pinned to 12.1.3 — the last release before the nanosecond-timestamp
+        # regression in 12.2.x's openvulnerability-client...
+        # TODO: revisit quarterly; roll forward when a newer version is safe.
         if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true' }}
         working-directory: ./backend
-        run: mvn -B -ntp org.owasp:dependency-check-maven:check
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: |
+          mvn -B -ntp \
+            org.owasp:dependency-check-maven:12.1.3:check \
+            -DnvdApiKey=\"${NVD_API_KEY:-}\"
\`\`\`

**+18 / -1 lines, single file (`security.yml`).** No other workflows, no pom.xml, no new dependencies.

## Repo secret status

Confirmed the \`NVD_API_KEY\` secret is set in the repo (\`gh secret list\` shows it at \`2026-04-27T10:56:37Z\`). This means CI will hit the authenticated NVD endpoint immediately after merge.

## Acceptance Criteria

- [x] \`Dependency Scan\` no longer fails with the timestamp parse error
- [x] Plugin version is explicitly pinned in the workflow
- [x] NVD API key passed through securely (via secret, never logged)
- [x] Workflow still works for forks / contributors without secret access (anonymous fallback)
- [x] No \`pom.xml\` or other code changes — workflow-only fix

## Verification

### Pre-merge (this PR's CI run)
- [ ] \`Dependency Scan\` job: **pass** (no timestamp parse error)
- [ ] \`backend-dependency-check\` artifact uploaded with an HTML scan report (not a Java stack trace)
- [ ] \`Security Summary\` job: **pass**

### Post-merge
- [ ] Push to \`main\` → Security workflow re-runs cleanly
- [ ] Next backend Dependabot PR → \`Dependency Scan\` green out of the gate

### Rollback
If 12.1.3 is also affected by a different regression: edit the version string on line 95 (one-line change), push, re-run. Other fallbacks documented in plan: \`12.1.0\` → \`11.1.1\`.

## Security Checklist

- [x] No hardcoded secrets — \`NVD_API_KEY\` only appears as \`${{ secrets.NVD_API_KEY }}\` and \`${NVD_API_KEY:-}\` (env var, automatically redacted in logs)
- [x] No new attack surface — the workflow still runs the same security tool, just at a known-good version with proper authentication
- [x] Optional secret — public forks can still run the workflow without it (graceful degradation)

## Out of scope (future work, separate PRs)

- Migrating away from OWASP Dependency-Check (Trivy / Snyk / OSV-Scanner / GitHub native) — only pursue if this regression cycle repeats
- Moving the plugin into \`backend/pom.xml\` \`<pluginManagement>\` for Dependabot tracking — defer until manual version-tracking becomes annoying
- Tuning \`-DfailBuildOnCVSS\` from default to explicit \`7\` (high) or \`9\` (critical)
- SBOM generation / cyclonedx-maven-plugin