### PR TITLE
docs: establish API documentation (OpenAPI/Swagger + reference)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -43,6 +43,16 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!-- API docs: springdoc-openapi serves an OpenAPI 3 spec at
+             /v3/api-docs and interactive Swagger UI at /swagger-ui.html,
+             generated from the controllers/DTOs so the docs stay in sync
+             with the code. 2.6.0 targets Spring Boot 3.3.x. -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+
         <!-- Database -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/backend/src/main/java/com/expensetracker/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/expensetracker/config/OpenApiConfig.java
@@ -1,0 +1,73 @@
+package com.expensetracker.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * Central OpenAPI / Swagger UI configuration.
+ *
+ * <p>springdoc-openapi turns this bean plus the controller/DTO annotations
+ * into a live OpenAPI 3 document served at:
+ * <ul>
+ *   <li><b>/v3/api-docs</b> — the raw JSON spec (import this into Postman)</li>
+ *   <li><b>/swagger-ui.html</b> — interactive Swagger UI</li>
+ * </ul>
+ *
+ * <p>A single {@code bearer-jwt} security scheme is declared and applied
+ * globally so the "Authorize" button in Swagger UI attaches the
+ * {@code Authorization: Bearer <token>} header to protected calls. The
+ * public auth endpoints (register/login/refresh) still work without it.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    private static final String BEARER_SCHEME = "bearer-jwt";
+
+    @Bean
+    public OpenAPI expenseTrackerOpenAPI() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .servers(List.of(
+                        new Server().url("http://localhost:8080").description("Local development")))
+                // Declare the scheme once under components...
+                .components(new Components().addSecuritySchemes(BEARER_SCHEME, bearerScheme()))
+                // ...and apply it to every operation by default.
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Expense Tracker API")
+                .version("v1")
+                .description("""
+                        REST API for the Expense Tracker application.
+
+                        **Authentication:** obtain an access token from `POST /api/auth/login`
+                        (or `/register`) and send it as `Authorization: Bearer <accessToken>`.
+                        Use the **Authorize** button above to set it for all requests here.
+
+                        **Response envelope:** auth endpoints return
+                        `{ success, data, error }`. See `docs/api/README.md` in the repo
+                        for the full conventions (error format, versioning, examples).""")
+                .contact(new Contact().name("Expense Tracker").url("https://github.com/Captain-jack0/Expense-Tracker"))
+                .license(new License().name("Educational use"));
+    }
+
+    private SecurityScheme bearerScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .description("Paste the accessToken returned by /api/auth/login (no 'Bearer ' prefix).");
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -19,6 +19,17 @@ app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:http://localhost:5173,http:/
 # Serialize java.time values (Instant) as ISO-8601 strings, not arrays
 spring.jackson.serialization.write-dates-as-timestamps=false
 
+# ================================================================
+# OpenAPI / Swagger UI (springdoc)
+# ================================================================
+# Spec JSON at /v3/api-docs (import into Postman), interactive UI at
+# /swagger-ui.html. See config/OpenApiConfig.java for metadata + the
+# JWT bearer security scheme, and docs/api/README.md for conventions.
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha
+
 # H2 Database Configuration (for development)
 # File-based storage so data SURVIVES restarts. The DB lives in
 # ./data/expensedb.mv.db relative to the backend working directory

--- a/backend/src/test/java/com/expensetracker/OpenApiDocsTest.java
+++ b/backend/src/test/java/com/expensetracker/OpenApiDocsTest.java
@@ -1,0 +1,48 @@
+package com.expensetracker;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies the springdoc-openapi documentation endpoints are wired up and
+ * describe the real API surface. Runs in the MOCK web environment (no real
+ * Tomcat port), so it exercises the /v3/api-docs controller directly.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class OpenApiDocsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("/v3/api-docs serves the OpenAPI spec with our metadata + JWT scheme")
+    void apiDocs_exposesMetadataAndSecurityScheme() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.openapi").exists())
+                .andExpect(jsonPath("$.info.title").value("Expense Tracker API"))
+                .andExpect(jsonPath("$.info.version").value("v1"))
+                .andExpect(jsonPath("$.components.securitySchemes.bearer-jwt.scheme").value("bearer"));
+    }
+
+    @Test
+    @DisplayName("/v3/api-docs documents the auth, expense and transaction endpoints")
+    void apiDocs_documentsCoreEndpoints() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.paths['/api/auth/login']").exists())
+                .andExpect(jsonPath("$.paths['/api/auth/register']").exists())
+                .andExpect(jsonPath("$.paths['/api/expenses']").exists())
+                .andExpect(jsonPath("$.paths['/api/transactions']").exists())
+                .andExpect(jsonPath("$.paths['/api/categories']").exists());
+    }
+}

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,299 @@
+# Expense Tracker — API Documentation
+
+Reference for the Expense Tracker REST API: conventions, authentication, error
+format, versioning, and per-endpoint request/response shapes.
+
+> **Live, always-in-sync docs:** the backend serves an auto-generated OpenAPI 3
+> spec and interactive UI (see [Interactive docs & tooling](#interactive-docs--tooling)).
+> This Markdown file is the human-readable overview and the source of truth for
+> **conventions** (auth flow, error format, versioning) that the generated spec
+> doesn't narrate.
+
+---
+
+## 1. Overview
+
+- **Base URL (local):** `http://localhost:8080`
+- **API root:** all endpoints are under `/api`
+- **Format:** JSON request and response bodies (`Content-Type: application/json`)
+- **Auth:** stateless JWT (Bearer access token + refresh token) — see [Authentication](#3-authentication)
+- **Dates:** ISO-8601 strings (`2026-07-15T12:00:00Z` for timestamps, `2026-07-15` for dates)
+- **CORS:** the Vite dev origins (`http://localhost:5173`, `http://127.0.0.1:5173`) are allowed by default; override with `APP_CORS_ALLOWED_ORIGINS`.
+
+---
+
+## 2. Response conventions
+
+### Envelope (auth endpoints)
+
+The `/api/auth/*` endpoints wrap their payload in a standard envelope:
+
+```json
+{
+  "success": true,
+  "data":    { "...": "endpoint-specific payload" },
+  "error":   null,
+  "message": null
+}
+```
+
+| Field     | Type            | Notes                                             |
+|-----------|-----------------|---------------------------------------------------|
+| `success` | boolean         | `true` on success, `false` on error               |
+| `data`    | object \| null  | The payload on success; `null` on error           |
+| `error`   | string \| null  | Human-readable error message on failure           |
+| `message` | string \| null  | Optional info message (e.g. "Logged out")         |
+
+### Raw payloads (resource endpoints)
+
+> ⚠️ **Current state:** the resource controllers (`/api/expenses`,
+> `/api/categories`, `/api/subcategories`, `/api/transactions`) currently return
+> the entity or array **directly**, *not* wrapped in the envelope above. The
+> envelope is the intended standard; aligning the resource endpoints to it is
+> tracked as backend follow-up work. Documented here as-is so integrators aren't
+> surprised.
+
+---
+
+## 3. Authentication
+
+JWT-based, stateless. Two tokens are issued:
+
+| Token           | Lifetime | Sent as                              | Used for                    |
+|-----------------|----------|--------------------------------------|-----------------------------|
+| `accessToken`   | 1 hour   | `Authorization: Bearer <accessToken>`| Every authenticated request |
+| `refreshToken`  | 7 days   | request body to `/api/auth/refresh`  | Getting a fresh access token|
+
+**Flow**
+
+1. `POST /api/auth/register` or `POST /api/auth/login` → returns `{ user, accessToken, refreshToken }`.
+2. Send `Authorization: Bearer <accessToken>` on protected calls (e.g. `GET /api/auth/me`).
+3. When the access token expires (401), call `POST /api/auth/refresh` with the refresh token to get a new pair.
+4. `POST /api/auth/logout` is a client-side discard (tokens are stateless); it returns 200 for a stable contract.
+
+Passwords are hashed with **BCrypt**; the hash is never returned. There is no
+Spring Security filter chain yet — `GET /api/auth/me` validates the Bearer token
+manually. Resource endpoints are **not yet auth-protected** (backend follow-up).
+
+---
+
+## 4. Error handling
+
+All errors handled by `GlobalExceptionHandler` render as the failure envelope:
+
+```json
+{ "success": false, "data": null, "error": "Invalid email or password", "message": null }
+```
+
+| Status | When                                                            |
+|--------|-----------------------------------------------------------------|
+| `400`  | Bean-validation failure (returns the first field message), or malformed/unreadable JSON body |
+| `401`  | Bad credentials, missing/invalid/expired token, invalid token type |
+| `403`  | Forbidden (`ApiException.forbidden`)                            |
+| `404`  | Resource not found                                              |
+| `409`  | Conflict — e.g. email already registered                       |
+| `500`  | Unhandled server error (generic message; details are logged server-side, never leaked) |
+
+---
+
+## 5. Versioning
+
+- **Current:** `v1` (the OpenAPI `info.version`). The API surface lives under `/api`
+  with no version path segment yet.
+- **Strategy going forward:** introduce **URI versioning** (`/api/v1/...`) at the
+  first breaking change. Non-breaking additions (new fields, new endpoints) ship
+  without a version bump. When `/api/v2` lands, `/api/v1` is kept until clients
+  migrate, then deprecated with a sunset window.
+
+---
+
+## 6. Endpoints
+
+### Auth — `/api/auth`
+
+| Method | Path        | Auth | Body                                   | Returns (in envelope)          |
+|--------|-------------|------|----------------------------------------|--------------------------------|
+| POST   | `/register` | —    | `RegisterRequest`                      | `AuthResponse` (201)           |
+| POST   | `/login`    | —    | `LoginRequest`                         | `AuthResponse` (200)           |
+| GET    | `/me`       | ✅   | —                                      | `UserDto` (200)                |
+| POST   | `/refresh`  | —    | `{ "refreshToken": "..." }`            | `AuthResponse` (200)           |
+| POST   | `/logout`   | —    | —                                      | `null` + message (200)         |
+
+### Expenses — `/api/expenses` *(raw payloads)*
+
+| Method | Path                        | Body      | Returns              |
+|--------|-----------------------------|-----------|----------------------|
+| GET    | `/`                         | —         | `Expense[]`          |
+| GET    | `/{id}`                     | —         | `Expense` / 404      |
+| POST   | `/`                         | `Expense` | `Expense` (201)      |
+| PUT    | `/{id}`                     | `Expense` | `Expense` / 404      |
+| DELETE | `/{id}`                     | —         | 204                  |
+| GET    | `/category/{category}`      | —         | `Expense[]`          |
+| GET    | `/date-range?startDate&endDate` | —     | `Expense[]` (ISO dates) |
+| GET    | `/categories`               | —         | `string[]`           |
+
+### Categories — `/api/categories` *(raw payloads)*
+
+| Method | Path      | Returns       |
+|--------|-----------|---------------|
+| GET    | `/`       | `Category[]`  |
+| POST   | `/`       | `Category`    |
+| PUT    | `/{id}`   | `Category`    |
+| DELETE | `/{id}`   | 204           |
+
+### SubCategories — `/api/subcategories` *(raw payloads)*
+
+| Method | Path      | Returns          |
+|--------|-----------|------------------|
+| GET    | `/`       | `SubCategory[]`  |
+| POST   | `/`       | `SubCategory`    |
+| PUT    | `/{id}`   | `SubCategory`    |
+| DELETE | `/{id}`   | 204              |
+
+### Transactions — `/api/transactions` *(raw payloads)*
+
+| Method | Path      | Returns          |
+|--------|-----------|------------------|
+| GET    | `/`       | `Transaction[]`  |
+| POST   | `/`       | `Transaction`    |
+| PUT    | `/{id}`   | `Transaction`    |
+| DELETE | `/{id}`   | 204              |
+
+---
+
+## 7. Example payloads
+
+### Register
+
+`POST /api/auth/register`
+
+```json
+{
+  "email": "ada@example.com",
+  "password": "correcthorse",
+  "firstName": "Ada",
+  "lastName": "Lovelace"
+}
+```
+
+Validation: `email` valid, `password` ≥ 8 chars, `firstName`/`lastName` non-blank.
+
+**201 Created**
+
+```json
+{
+  "success": true,
+  "data": {
+    "user": {
+      "id": "4de9342a-ca41-4865-8813-0772d7eb1fcb",
+      "email": "ada@example.com",
+      "firstName": "Ada",
+      "lastName": "Lovelace",
+      "currency": "USD",
+      "timezone": "UTC",
+      "isActive": true,
+      "emailVerified": false,
+      "createdAt": "2026-07-15T12:00:00Z",
+      "updatedAt": "2026-07-15T12:00:00Z"
+    },
+    "accessToken": "eyJhbGciOiJIUzUxMiJ9...",
+    "refreshToken": "eyJhbGciOiJIUzUxMiJ9..."
+  },
+  "error": null,
+  "message": null
+}
+```
+
+### Create an expense
+
+`POST /api/expenses`  (raw payload — not enveloped)
+
+```json
+{
+  "title": "Groceries",
+  "amount": 42.50,
+  "category": "Food",
+  "description": "Weekly shop",
+  "date": "2026-07-15"
+}
+```
+
+**201 Created**
+
+```json
+{
+  "id": 1,
+  "title": "Groceries",
+  "amount": 42.50,
+  "category": "Food",
+  "description": "Weekly shop",
+  "date": "2026-07-15",
+  "createdAt": "2026-07-15"
+}
+```
+
+---
+
+## 8. Common scenarios
+
+**Sign in and call a protected endpoint**
+
+```bash
+# 1. Log in, capture the access token
+TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"ada@example.com","password":"correcthorse"}' \
+  | jq -r '.data.accessToken')
+
+# 2. Use it
+curl -s http://localhost:8080/api/auth/me -H "Authorization: Bearer $TOKEN"
+```
+
+**Refresh an expired token**
+
+```bash
+curl -s -X POST http://localhost:8080/api/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"refreshToken":"<refreshToken>"}'
+```
+
+**Filter expenses by date range**
+
+```bash
+curl -s "http://localhost:8080/api/expenses/date-range?startDate=2026-07-01&endDate=2026-07-31"
+```
+
+---
+
+## Interactive docs & tooling
+
+The backend auto-generates the spec from the controllers via **springdoc-openapi**,
+so it never drifts from the code.
+
+| Resource        | URL (local)                          |
+|-----------------|--------------------------------------|
+| Swagger UI      | `http://localhost:8080/swagger-ui.html` |
+| OpenAPI 3 spec  | `http://localhost:8080/v3/api-docs`  |
+
+- **Swagger UI:** click **Authorize**, paste an `accessToken` (from `/api/auth/login`),
+  and try any endpoint in-browser.
+- **Postman:** *Import → Link →* `http://localhost:8080/v3/api-docs`. Postman builds
+  a collection from the OpenAPI spec automatically.
+- **Metadata & the JWT security scheme** are defined in
+  [`OpenApiConfig.java`](../../backend/src/main/java/com/expensetracker/config/OpenApiConfig.java).
+
+---
+
+## Where docs live
+
+```
+docs/
+└── api/
+    └── README.md        ← this file (conventions + overview; source of truth for narrative)
+backend/.../config/OpenApiConfig.java   ← OpenAPI metadata + JWT scheme
+/v3/api-docs, /swagger-ui.html          ← generated per-endpoint reference (run the backend)
+```
+
+Keep **conventions** (auth, errors, versioning) here; let **per-endpoint detail**
+come from the generated spec. When you add or change an endpoint, the spec updates
+automatically — only touch this file if a *convention* changes.


### PR DESCRIPTION
## Summary

Establishes structured, tool-compatible API documentation for the Expense Tracker backend — **closes #16**.

Two complementary layers:
1. **Generated, always-in-sync** — `springdoc-openapi` serves an OpenAPI 3 spec + interactive Swagger UI straight from the controllers, so per-endpoint detail never drifts from the code.
2. **Hand-written conventions** — a Markdown reference that documents what a generated spec can't narrate: the response envelope, auth flow, error format, versioning strategy, usage scenarios, and where docs live.

## What's included

- **`backend/pom.xml`** — add `springdoc-openapi-starter-webmvc-ui:2.6.0` (targets Spring Boot 3.3.x).
- **`config/OpenApiConfig.java`** — OpenAPI metadata (title/version/description) + a global `bearer-jwt` security scheme so Swagger UI's **Authorize** button attaches `Authorization: Bearer <token>`.
- **`application.properties`** — springdoc paths + UI sorting.
- **`docs/api/README.md`** — overview, response conventions, authentication, error handling, versioning, full endpoint tables (5 controllers / ~26 endpoints), example payloads, common cURL scenarios, and Swagger/Postman integration.
- **`OpenApiDocsTest.java`** — MockMvc test (no Tomcat) asserting `/v3/api-docs` serves the metadata, the JWT scheme, and the auth/expense/transaction/category paths.

## Endpoints

| Where | URL (local) |
|-------|-------------|
| Swagger UI | `http://localhost:8080/swagger-ui.html` |
| OpenAPI 3 spec (Postman import) | `http://localhost:8080/v3/api-docs` |

## Acceptance criteria (issue #16)

- [x] Structured documentation established
- [x] Overview of existing endpoints (tables per controller group)
- [x] Request/response formats per endpoint group
- [x] Example request/response payloads
- [x] Authentication approach documented (JWT bearer + refresh flow)
- [x] Error handling strategy + standard error response
- [x] API versioning approach (URI versioning strategy)
- [x] Common usage scenarios (cURL examples)
- [x] Swagger/OpenAPI + Postman-compatible structure
- [x] Repo location + tool integration documented

## Test plan

- [x] `mvn test` → BUILD SUCCESS (3 tests: 2 docs + 1 smoke)
- [x] OpenAPI spec verified via MockMvc (title, version, `bearer-jwt` scheme, core paths present)
- [ ] CI confirms on Linux (live Swagger UI / `/v3/api-docs`)

> Note: the docs accurately flag the current state — auth endpoints use the `{success,data,error,message}` envelope while resource endpoints (`/api/expenses` etc.) still return raw payloads. Aligning them is separate backend follow-up, not part of this docs PR.
