### PR TITLE
docs: document transactions/categories endpoints, data model & recurring behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,15 @@ Expense Tracker/
 - ✅ TypeScript strict mode
 
 ### 🔄 Phase 2 (In Progress) - Weeks 5-10
+- ✅ Income/expense tracking — categorized transactions API (`/api/transactions`) with filters
+- ✅ Category system — categories + sub-categories with monthly limits (`/api/categories`, `/api/subcategories`)
+- 🟡 Recurring & installment (*taksitli*) — data model shipped (schema-reserved fields); generation engine not yet implemented (see [docs/api/README.md](./docs/api/README.md#7-recurring--installment-behavior))
 - 📅 Multiple account management (CRUD)
-- 📅 Income/expense tracking
-- 📅 Category system
 - 📅 Goal tracking with progress visualization
 - 📅 Dashboard with animated charts (Recharts)
 - 📅 Basic investment tracking
+
+> **API reference:** see [docs/api/README.md](./docs/api/README.md) and the live Swagger UI at `/swagger-ui.html`.
 
 ### ⏳ Phase 3 (Planned) - Weeks 11-16
 - 📅 Investment portfolio tracking

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,13 +1,13 @@
 # Expense Tracker — API Documentation
 
-Reference for the Expense Tracker REST API: conventions, authentication, error
-format, versioning, and per-endpoint request/response shapes.
+Reference for the Expense Tracker REST API: conventions, authentication, data
+model, error format, versioning, and per-endpoint request/response shapes.
 
 > **Live, always-in-sync docs:** the backend serves an auto-generated OpenAPI 3
 > spec and interactive UI (see [Interactive docs & tooling](#interactive-docs--tooling)).
 > This Markdown file is the human-readable overview and the source of truth for
-> **conventions** (auth flow, error format, versioning) that the generated spec
-> doesn't narrate.
+> **conventions** (auth flow, data model, error format, versioning) that the
+> generated spec doesn't narrate.
 
 ---
 
@@ -17,16 +17,20 @@ format, versioning, and per-endpoint request/response shapes.
 - **API root:** all endpoints are under `/api`
 - **Format:** JSON request and response bodies (`Content-Type: application/json`)
 - **Auth:** stateless JWT (Bearer access token + refresh token) — see [Authentication](#3-authentication)
-- **Dates:** ISO-8601 strings (`2026-07-15T12:00:00Z` for timestamps, `2026-07-15` for dates)
+- **Dates:** ISO-8601 strings — `2026-07-15T12:00:00Z` for timestamps, `2026-07-15` for calendar dates
+- **Money:** decimal `amount` + 3-letter `currency` code (default `USD`)
+- **IDs:** UUID strings (except the legacy `/api/expenses` resource, which uses numeric ids)
 - **CORS:** the Vite dev origins (`http://localhost:5173`, `http://127.0.0.1:5173`) are allowed by default; override with `APP_CORS_ALLOWED_ORIGINS`.
 
 ---
 
 ## 2. Response conventions
 
-### Envelope (auth endpoints)
+### Standard envelope
 
-The `/api/auth/*` endpoints wrap their payload in a standard envelope:
+The auth endpoints **and** all current resource endpoints
+(`/api/categories`, `/api/subcategories`, `/api/transactions`) wrap their
+payload in this envelope:
 
 ```json
 {
@@ -40,18 +44,16 @@ The `/api/auth/*` endpoints wrap their payload in a standard envelope:
 | Field     | Type            | Notes                                             |
 |-----------|-----------------|---------------------------------------------------|
 | `success` | boolean         | `true` on success, `false` on error               |
-| `data`    | object \| null  | The payload on success; `null` on error           |
+| `data`    | object \| array \| null | Payload on success; `null` on error        |
 | `error`   | string \| null  | Human-readable error message on failure           |
-| `message` | string \| null  | Optional info message (e.g. "Logged out")         |
+| `message` | string \| null  | Optional info message (e.g. "Transaction deleted")|
 
-### Raw payloads (resource endpoints)
+### Legacy exception — `/api/expenses`
 
-> ⚠️ **Current state:** the resource controllers (`/api/expenses`,
-> `/api/categories`, `/api/subcategories`, `/api/transactions`) currently return
-> the entity or array **directly**, *not* wrapped in the envelope above. The
-> envelope is the intended standard; aligning the resource endpoints to it is
-> tracked as backend follow-up work. Documented here as-is so integrators aren't
-> surprised.
+> ⚠️ The original `/api/expenses` controller predates this convention: it returns
+> the entity/array **directly** (no envelope) and is **not** user-scoped or
+> auth-protected. It is kept for backward compatibility; new work uses
+> `/api/transactions`. Treat `/api/expenses` as deprecated.
 
 ---
 
@@ -67,116 +69,203 @@ JWT-based, stateless. Two tokens are issued:
 **Flow**
 
 1. `POST /api/auth/register` or `POST /api/auth/login` → returns `{ user, accessToken, refreshToken }`.
-2. Send `Authorization: Bearer <accessToken>` on protected calls (e.g. `GET /api/auth/me`).
-3. When the access token expires (401), call `POST /api/auth/refresh` with the refresh token to get a new pair.
-4. `POST /api/auth/logout` is a client-side discard (tokens are stateless); it returns 200 for a stable contract.
+2. Send `Authorization: Bearer <accessToken>` on protected calls.
+3. On `401` (expired token), call `POST /api/auth/refresh` with the refresh token for a new pair.
+4. `POST /api/auth/logout` is a client-side discard (tokens are stateless); returns 200 for a stable contract.
+
+**Which endpoints require auth**
+
+- ✅ **Protected & user-scoped:** `/api/auth/me`, and every `/api/categories`,
+  `/api/subcategories`, `/api/transactions` call. The user id is taken from the
+  Bearer token (`@CurrentUser`); a missing/invalid token returns **401**, and a
+  user only ever sees or edits **their own** rows.
+- ❌ **Unprotected (legacy):** `/api/expenses/*` — no token required.
 
 Passwords are hashed with **BCrypt**; the hash is never returned. There is no
-Spring Security filter chain yet — `GET /api/auth/me` validates the Bearer token
-manually. Resource endpoints are **not yet auth-protected** (backend follow-up).
+Spring Security filter chain yet — the `@CurrentUser` argument resolver validates
+the Bearer token per request.
 
 ---
 
 ## 4. Error handling
 
-All errors handled by `GlobalExceptionHandler` render as the failure envelope:
+All errors are rendered by `GlobalExceptionHandler` as the failure envelope:
 
 ```json
-{ "success": false, "data": null, "error": "Invalid email or password", "message": null }
+{ "success": false, "data": null, "error": "A sub-category is required for this category", "message": null }
 ```
 
 | Status | When                                                            |
 |--------|-----------------------------------------------------------------|
-| `400`  | Bean-validation failure (returns the first field message), or malformed/unreadable JSON body |
-| `401`  | Bad credentials, missing/invalid/expired token, invalid token type |
+| `400`  | Bean-validation failure (returns the first field message), malformed JSON, or a broken business rule (e.g. missing/foreign sub-category) |
+| `401`  | Bad credentials, or missing/invalid/expired token                |
 | `403`  | Forbidden (`ApiException.forbidden`)                            |
-| `404`  | Resource not found                                              |
+| `404`  | Resource not found (or not owned by the caller)                 |
 | `409`  | Conflict — e.g. email already registered                       |
-| `500`  | Unhandled server error (generic message; details are logged server-side, never leaked) |
+| `500`  | Unhandled server error (generic message; details logged server-side, never leaked) |
 
 ---
 
-## 5. Versioning
+## 5. Data model
 
-- **Current:** `v1` (the OpenAPI `info.version`). The API surface lives under `/api`
-  with no version path segment yet.
-- **Strategy going forward:** introduce **URI versioning** (`/api/v1/...`) at the
-  first breaking change. Non-breaking additions (new fields, new endpoints) ship
-  without a version bump. When `/api/v2` lands, `/api/v1` is kept until clients
-  migrate, then deprecated with a sunset window.
+All entities are per-user. Timestamps (`createdAt`, `updatedAt`) are ISO-8601.
+
+### Category — top-level bucket
+
+| Field       | Type    | Notes                                                    |
+|-------------|---------|----------------------------------------------------------|
+| `id`        | UUID    |                                                          |
+| `name`      | string  | ≤ 100 chars; **unique per user**                         |
+| `kind`      | enum    | `INCOME` \| `EXPENSE`                                    |
+| `bucket`    | enum    | `INCOME` \| `NEEDS` \| `WANTS` \| `SAVINGS` \| `OTHER` (50/30/20 budgeting) |
+| `icon`      | string? | optional                                                 |
+| `color`     | string? | optional                                                 |
+| `isSystem`  | boolean | seeded defaults vs. user-created                         |
+| `sortOrder` | int     | display order                                            |
+
+### SubCategory — belongs to a Category
+
+| Field          | Type      | Notes                                        |
+|----------------|-----------|----------------------------------------------|
+| `id`           | UUID      |                                              |
+| `categoryId`   | UUID      | parent category                              |
+| `name`         | string    | ≤ 100 chars; **unique per category**         |
+| `icon`,`color` | string?   | optional                                     |
+| `monthlyLimit` | decimal?  | optional monthly cap; when set must be **> 0** |
+| `isSystem`     | boolean   |                                              |
+
+### Transaction — a single money movement
+
+| Field              | Type    | Notes                                                  |
+|--------------------|---------|--------------------------------------------------------|
+| `id`               | UUID    |                                                        |
+| `name`             | string  | ≤ 200 chars                                            |
+| `amount`           | decimal | **> 0**                                                |
+| `currency`         | string  | 3-letter code, upper-cased; default `USD`              |
+| `categoryId`       | UUID    | required                                               |
+| `subCategoryId`    | UUID?   | **required when the category has sub-categories**      |
+| `type`             | enum    | `INCOME` \| `EXPENSE`                                  |
+| `transactionDate`  | date    | ISO date                                               |
+| `note`             | string? | ≤ 500 chars                                            |
+| `sourceType`       | enum    | `MANUAL` \| `RECURRING` \| `INSTALLMENT` — see [below](#7-recurring--installment-behavior) |
+| `installmentNo`    | int?    | which installment this row is (recurring/installment only) |
+
+> The entity also carries `recurringRuleId` and `installmentPlanId` FK columns
+> (not exposed in the DTO yet) reserved for the engines described below.
+
+### Core entry rules (enforced server-side)
+
+- The `categoryId` must belong to the caller.
+- A `subCategoryId` is **required** when the chosen category has any
+  sub-categories, is **rejected** when the category has none, and must belong to
+  the selected category — otherwise `400`.
+- `amount` must be `> 0`; `currency` is normalised to upper-case (default `USD`).
 
 ---
 
 ## 6. Endpoints
 
-### Auth — `/api/auth`
+### Auth — `/api/auth`  *(enveloped)*
 
-| Method | Path        | Auth | Body                                   | Returns (in envelope)          |
-|--------|-------------|------|----------------------------------------|--------------------------------|
-| POST   | `/register` | —    | `RegisterRequest`                      | `AuthResponse` (201)           |
-| POST   | `/login`    | —    | `LoginRequest`                         | `AuthResponse` (200)           |
-| GET    | `/me`       | ✅   | —                                      | `UserDto` (200)                |
-| POST   | `/refresh`  | —    | `{ "refreshToken": "..." }`            | `AuthResponse` (200)           |
-| POST   | `/logout`   | —    | —                                      | `null` + message (200)         |
+| Method | Path        | Auth | Body                          | Returns                |
+|--------|-------------|------|-------------------------------|------------------------|
+| POST   | `/register` | —    | `RegisterRequest`             | `AuthResponse` (201)   |
+| POST   | `/login`    | —    | `LoginRequest`                | `AuthResponse` (200)   |
+| GET    | `/me`       | ✅   | —                             | `UserDto` (200)        |
+| POST   | `/refresh`  | —    | `{ "refreshToken": "..." }`   | `AuthResponse` (200)   |
+| POST   | `/logout`   | —    | —                             | `null` + message (200) |
 
-### Expenses — `/api/expenses` *(raw payloads)*
+### Categories — `/api/categories`  *(enveloped, auth ✅)*
 
-| Method | Path                        | Body      | Returns              |
-|--------|-----------------------------|-----------|----------------------|
-| GET    | `/`                         | —         | `Expense[]`          |
-| GET    | `/{id}`                     | —         | `Expense` / 404      |
-| POST   | `/`                         | `Expense` | `Expense` (201)      |
-| PUT    | `/{id}`                     | `Expense` | `Expense` / 404      |
-| DELETE | `/{id}`                     | —         | 204                  |
-| GET    | `/category/{category}`      | —         | `Expense[]`          |
-| GET    | `/date-range?startDate&endDate` | —     | `Expense[]` (ISO dates) |
-| GET    | `/categories`               | —         | `string[]`           |
+| Method | Path      | Body              | Returns              |
+|--------|-----------|-------------------|----------------------|
+| GET    | `/`       | —                 | `CategoryDto[]`      |
+| POST   | `/`       | `CategoryRequest` | `CategoryDto` (201)  |
+| PUT    | `/{id}`   | `CategoryRequest` | `CategoryDto`        |
+| DELETE | `/{id}`   | —                 | `null` + message     |
 
-### Categories — `/api/categories` *(raw payloads)*
+`CategoryRequest`: `{ name, kind, bucket, icon?, color? }`
 
-| Method | Path      | Returns       |
-|--------|-----------|---------------|
-| GET    | `/`       | `Category[]`  |
-| POST   | `/`       | `Category`    |
-| PUT    | `/{id}`   | `Category`    |
-| DELETE | `/{id}`   | 204           |
+### SubCategories — `/api/subcategories`  *(enveloped, auth ✅)*
 
-### SubCategories — `/api/subcategories` *(raw payloads)*
+| Method | Path                      | Body                 | Returns             |
+|--------|---------------------------|----------------------|---------------------|
+| GET    | `/?categoryId={uuid}`     | —                    | `SubCategoryDto[]`  (optional filter) |
+| POST   | `/`                       | `SubCategoryRequest` | `SubCategoryDto` (201) |
+| PUT    | `/{id}`                   | `SubCategoryRequest` | `SubCategoryDto`    |
+| DELETE | `/{id}`                   | —                    | `null` + message    |
 
-| Method | Path      | Returns          |
-|--------|-----------|------------------|
-| GET    | `/`       | `SubCategory[]`  |
-| POST   | `/`       | `SubCategory`    |
-| PUT    | `/{id}`   | `SubCategory`    |
-| DELETE | `/{id}`   | 204              |
+`SubCategoryRequest`: `{ categoryId, name, icon?, color?, monthlyLimit? }`
 
-### Transactions — `/api/transactions` *(raw payloads)*
+### Transactions — `/api/transactions`  *(enveloped, auth ✅)*
 
-| Method | Path      | Returns          |
-|--------|-----------|------------------|
-| GET    | `/`       | `Transaction[]`  |
-| POST   | `/`       | `Transaction`    |
-| PUT    | `/{id}`   | `Transaction`    |
-| DELETE | `/{id}`   | 204              |
+| Method | Path      | Query / Body                              | Returns               |
+|--------|-----------|-------------------------------------------|-----------------------|
+| GET    | `/`       | filters: `categoryId`, `subCategoryId`, `type`, `from`, `to` (all optional) | `TransactionDto[]` (newest first) |
+| POST   | `/`       | `TransactionRequest`                      | `TransactionDto` (201)|
+| PUT    | `/{id}`   | `TransactionRequest`                      | `TransactionDto`      |
+| DELETE | `/{id}`   | —                                         | `null` + message      |
+
+`TransactionRequest`: `{ name, amount, currency?, categoryId, subCategoryId?, type, transactionDate, note? }`
+
+Results are sorted by `transactionDate` then `createdAt`, descending. `from`/`to`
+are inclusive ISO dates.
+
+### Expenses — `/api/expenses`  *(legacy, raw payloads, no auth)*
+
+Deprecated first-generation endpoint kept for backward compatibility. CRUD plus
+`/category/{category}`, `/date-range?startDate&endDate`, `/categories`. Prefer
+`/api/transactions` for new work.
 
 ---
 
-## 7. Example payloads
+## 7. Recurring & installment behavior
 
-### Register
+> **Status: data model shipped, generation engine NOT yet implemented.**
 
-`POST /api/auth/register`
+The transaction schema is deliberately future-proofed for two upcoming features,
+but **no endpoints create recurring rules or installment plans yet, and nothing
+generates future rows** — every transaction created today is `sourceType: MANUAL`.
+
+| Concept          | Intended behavior (per the feature plan)                                             | Today |
+|------------------|--------------------------------------------------------------------------------------|-------|
+| **Recurring** (periodic) | A rule (e.g. "rent, monthly") **materializes** real `Transaction` rows on a schedule + catch-up at login, so the user never re-enters it. Rows carry `sourceType=RECURRING` + `recurringRuleId`. | Not implemented — no `RecurringRule` model/endpoint. |
+| **Installment** (*taksitli*) | A fixed total split into **N equal monthly** charges from a start date (e.g. 12.000 ₺ ÷ 12 = 1.000 ₺ × 12). Rows carry `sourceType=INSTALLMENT`, `installmentPlanId`, `installmentNo`. | Not implemented — no `InstallmentPlan` model/endpoint. |
+
+**What exists now (schema-only):**
+
+- `SourceType` enum: `MANUAL` (default today), `RECURRING`, `INSTALLMENT`.
+- `Transaction.recurringRuleId`, `Transaction.installmentPlanId`, `Transaction.installmentNo` columns.
+- `sourceType` and `installmentNo` are exposed read-only in `TransactionDto`.
+
+**What is missing (tracked as future epics):**
+
+- `RecurringRule` / `InstallmentPlan` entities, their CRUD endpoints, and the
+  scheduled/catch-up generation engine.
+
+See [`plan/FEATURE_CATEGORIES_TRANSACTIONS.md`](../../plan/FEATURE_CATEGORIES_TRANSACTIONS.md)
+for the full design (Epic 4 = recurring, Epic 5 = installments).
+
+---
+
+## 8. Example payloads
+
+### Create a transaction
+
+`POST /api/transactions`  ·  `Authorization: Bearer <accessToken>`
 
 ```json
 {
-  "email": "ada@example.com",
-  "password": "correcthorse",
-  "firstName": "Ada",
-  "lastName": "Lovelace"
+  "name": "Weekly groceries",
+  "amount": 42.50,
+  "currency": "USD",
+  "categoryId": "9b1f...needs-uuid",
+  "subCategoryId": "3c7a...groceries-uuid",
+  "type": "EXPENSE",
+  "transactionDate": "2026-07-15",
+  "note": "Migros"
 }
 ```
-
-Validation: `email` valid, `password` ≥ 8 chars, `firstName`/`lastName` non-blank.
 
 **201 Created**
 
@@ -184,116 +273,96 @@ Validation: `email` valid, `password` ≥ 8 chars, `firstName`/`lastName` non-bl
 {
   "success": true,
   "data": {
-    "user": {
-      "id": "4de9342a-ca41-4865-8813-0772d7eb1fcb",
-      "email": "ada@example.com",
-      "firstName": "Ada",
-      "lastName": "Lovelace",
-      "currency": "USD",
-      "timezone": "UTC",
-      "isActive": true,
-      "emailVerified": false,
-      "createdAt": "2026-07-15T12:00:00Z",
-      "updatedAt": "2026-07-15T12:00:00Z"
-    },
-    "accessToken": "eyJhbGciOiJIUzUxMiJ9...",
-    "refreshToken": "eyJhbGciOiJIUzUxMiJ9..."
+    "id": "b2d4...",
+    "name": "Weekly groceries",
+    "amount": 42.50,
+    "currency": "USD",
+    "categoryId": "9b1f...needs-uuid",
+    "subCategoryId": "3c7a...groceries-uuid",
+    "type": "EXPENSE",
+    "transactionDate": "2026-07-15",
+    "note": "Migros",
+    "sourceType": "MANUAL",
+    "installmentNo": null,
+    "createdAt": "2026-07-15T12:00:00Z",
+    "updatedAt": "2026-07-15T12:00:00Z"
   },
   "error": null,
   "message": null
 }
 ```
 
-### Create an expense
+### Create a sub-category with a monthly limit
 
-`POST /api/expenses`  (raw payload — not enveloped)
+`POST /api/subcategories`
 
 ```json
-{
-  "title": "Groceries",
-  "amount": 42.50,
-  "category": "Food",
-  "description": "Weekly shop",
-  "date": "2026-07-15"
-}
+{ "categoryId": "9b1f...needs-uuid", "name": "Groceries", "monthlyLimit": 600.00 }
 ```
 
-**201 Created**
+### Validation error (missing required sub-category)
+
+**400 Bad Request**
 
 ```json
-{
-  "id": 1,
-  "title": "Groceries",
-  "amount": 42.50,
-  "category": "Food",
-  "description": "Weekly shop",
-  "date": "2026-07-15",
-  "createdAt": "2026-07-15"
-}
+{ "success": false, "data": null, "error": "A sub-category is required for this category", "message": null }
 ```
 
 ---
 
-## 8. Common scenarios
+## 9. Common scenarios
 
-**Sign in and call a protected endpoint**
+**Add an expense under Needs → Groceries**
 
 ```bash
-# 1. Log in, capture the access token
 TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"ada@example.com","password":"correcthorse"}' \
-  | jq -r '.data.accessToken')
+  -d '{"email":"ada@example.com","password":"correcthorse"}' | jq -r '.data.accessToken')
 
-# 2. Use it
-curl -s http://localhost:8080/api/auth/me -H "Authorization: Bearer $TOKEN"
+# List categories to get the ids
+curl -s http://localhost:8080/api/categories -H "Authorization: Bearer $TOKEN"
+
+# Create the transaction
+curl -s -X POST http://localhost:8080/api/transactions \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"Groceries","amount":42.5,"categoryId":"<needs>","subCategoryId":"<groceries>","type":"EXPENSE","transactionDate":"2026-07-15"}'
 ```
 
-**Refresh an expired token**
+**Filter this month's expenses in one category**
 
 ```bash
-curl -s -X POST http://localhost:8080/api/auth/refresh \
-  -H "Content-Type: application/json" \
-  -d '{"refreshToken":"<refreshToken>"}'
-```
-
-**Filter expenses by date range**
-
-```bash
-curl -s "http://localhost:8080/api/expenses/date-range?startDate=2026-07-01&endDate=2026-07-31"
+curl -s "http://localhost:8080/api/transactions?type=EXPENSE&categoryId=<uuid>&from=2026-07-01&to=2026-07-31" \
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 ---
 
 ## Interactive docs & tooling
 
-The backend auto-generates the spec from the controllers via **springdoc-openapi**,
-so it never drifts from the code.
+springdoc-openapi generates the spec from the controllers, so per-endpoint detail
+never drifts from the code.
 
-| Resource        | URL (local)                          |
-|-----------------|--------------------------------------|
+| Resource        | URL (local)                             |
+|-----------------|-----------------------------------------|
 | Swagger UI      | `http://localhost:8080/swagger-ui.html` |
-| OpenAPI 3 spec  | `http://localhost:8080/v3/api-docs`  |
+| OpenAPI 3 spec  | `http://localhost:8080/v3/api-docs`     |
 
-- **Swagger UI:** click **Authorize**, paste an `accessToken` (from `/api/auth/login`),
-  and try any endpoint in-browser.
-- **Postman:** *Import → Link →* `http://localhost:8080/v3/api-docs`. Postman builds
-  a collection from the OpenAPI spec automatically.
-- **Metadata & the JWT security scheme** are defined in
-  [`OpenApiConfig.java`](../../backend/src/main/java/com/expensetracker/config/OpenApiConfig.java).
+- **Swagger UI:** click **Authorize**, paste an `accessToken` (from `/api/auth/login`), and try any endpoint in-browser.
+- **Postman:** *Import → Link →* `http://localhost:8080/v3/api-docs`.
+- Metadata + the JWT scheme live in [`OpenApiConfig.java`](../../backend/src/main/java/com/expensetracker/config/OpenApiConfig.java).
 
 ---
 
 ## Where docs live
 
 ```
-docs/
-└── api/
-    └── README.md        ← this file (conventions + overview; source of truth for narrative)
-backend/.../config/OpenApiConfig.java   ← OpenAPI metadata + JWT scheme
-/v3/api-docs, /swagger-ui.html          ← generated per-endpoint reference (run the backend)
+docs/api/README.md                       ← this file: conventions, data model, endpoint overview
+backend/.../config/OpenApiConfig.java    ← OpenAPI metadata + JWT scheme
+/v3/api-docs, /swagger-ui.html           ← generated per-endpoint reference (run the backend)
+plan/FEATURE_CATEGORIES_TRANSACTIONS.md  ← feature design (recurring/installment epics)
 ```
 
-Keep **conventions** (auth, errors, versioning) here; let **per-endpoint detail**
-come from the generated spec. When you add or change an endpoint, the spec updates
-automatically — only touch this file if a *convention* changes.
+Keep **conventions & data model** here; let **per-endpoint request/response
+detail** come from the generated spec. When you add or change an endpoint the spec
+updates automatically — touch this file only when a *convention, the data model,
+or feature status* changes.


### PR DESCRIPTION
## Summary

Documents the shipped **categorized-transactions** feature — new endpoints, the data model, and recurring/installment behavior — and corrects a couple of conventions the first API-docs pass got wrong.

**AC — README reflects shipped feature:** ✅ `docs/api/README.md` (and the root README Phase 2 list) now describe exactly what ships today.

## What changed

**`docs/api/README.md`**
- **Conventions/auth corrected** — `/api/categories`, `/api/subcategories`, `/api/transactions` use the `ApiResponse` envelope and are **auth-protected + user-scoped** via `@CurrentUser` (401 without a token). The earlier pass wrongly described resource endpoints as raw/unprotected — that's true only of the **legacy `/api/expenses`**, now marked deprecated.
- **New: Data model** section — `Category`, `SubCategory`, `Transaction` field tables, the enums (`CategoryKind`, `Bucket`, `TransactionType`, `SourceType`), uniqueness/validation constraints, and the server-side entry rules (category ownership, conditional sub-category requirement, amount/currency normalisation).
- **New: Recurring & installment behavior** — documented **honestly**: the schema reserves fields (`sourceType`, `recurringRuleId`, `installmentPlanId`, `installmentNo`) but **no generation engine exists yet** — every transaction is `MANUAL` today. Recurring (Epic 4) and installment (Epic 5) are future work; links to `plan/FEATURE_CATEGORIES_TRANSACTIONS.md`.
- Rewrote the endpoint tables (filters, request bodies) and examples to match the actual controllers/DTOs.

**`README.md`**
- Phase 2 list marks income/expense tracking + category system as ✅ shipped, and recurring/installment as 🟡 (schema shipped, engine pending), with links to the API docs.

## Scope note

Documentation only — no code changes, so the generated OpenAPI spec is unaffected. Claims were verified by reading the controllers, services, DTOs and entities on `main`.

## Test plan

- [x] Markdown links/anchors checked (`#7-recurring--installment-behavior`)
- [x] Claims cross-checked against `TransactionController/Service`, `Category/SubCategory` controllers, DTOs, entities, and `CurrentUserArgumentResolver`
- [ ] CI green on this PR
