### PR TITLE
feat: sub-category management within a category (ET-FE-03)

### DIFF
--- a/frontend/src/components/categories/CategoryCard.tsx
+++ b/frontend/src/components/categories/CategoryCard.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import type { Category } from '../../types';
+import SubCategoryPanel from './SubCategoryPanel';
 
 interface CategoryCardProps {
   category: Category;
@@ -6,61 +8,81 @@ interface CategoryCardProps {
   onDelete: (category: Category) => void;
 }
 
-/** Single category row. System categories are read-only (no edit/delete). */
+/**
+ * Single category row. Expands to reveal its sub-category manager.
+ * System categories are read-only (no edit/delete of the category itself).
+ */
 function CategoryCard({ category, onEdit, onDelete }: CategoryCardProps) {
   const isOptimistic = category.id.startsWith('temp-');
+  const [expanded, setExpanded] = useState(false);
 
   return (
-    <div
-      className={`flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2.5 ${
-        isOptimistic ? 'opacity-60' : ''
-      }`}
-    >
-      <span
-        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-lg"
-        style={{ backgroundColor: (category.color ?? '#e5e7eb') + '22' }}
-        aria-hidden="true"
-      >
-        {category.icon ?? '🏷️'}
-      </span>
+    <div className={`overflow-hidden rounded-lg border border-gray-200 bg-white ${isOptimistic ? 'opacity-60' : ''}`}>
+      <div className="flex items-center gap-3 px-3 py-2.5">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          disabled={isOptimistic}
+          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 disabled:opacity-30"
+          aria-label={`${expanded ? 'Collapse' : 'Expand'} ${category.name}`}
+          aria-expanded={expanded}
+        >
+          <svg
+            className={`h-4 w-4 transition-transform ${expanded ? 'rotate-90' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
 
-      <div className="min-w-0 flex-1">
-        <p className="truncate font-medium text-gray-900">{category.name}</p>
-        <p className="text-xs text-gray-500">
-          {category.kind === 'INCOME' ? 'Income' : 'Expense'}
-        </p>
+        <span
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-lg"
+          style={{ backgroundColor: (category.color ?? '#e5e7eb') + '22' }}
+          aria-hidden="true"
+        >
+          {category.icon ?? '🏷️'}
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-medium text-gray-900">{category.name}</p>
+          <p className="text-xs text-gray-500">{category.kind === 'INCOME' ? 'Income' : 'Expense'}</p>
+        </div>
+
+        {category.isSystem ? (
+          <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">System</span>
+        ) : (
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => onEdit(category)}
+              disabled={isOptimistic}
+              className="rounded p-1.5 text-gray-500 hover:bg-gray-100 hover:text-primary-600 disabled:opacity-40"
+              aria-label={`Edit ${category.name}`}
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={() => onDelete(category)}
+              disabled={isOptimistic}
+              className="rounded p-1.5 text-gray-500 hover:bg-red-50 hover:text-danger disabled:opacity-40"
+              aria-label={`Delete ${category.name}`}
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          </div>
+        )}
       </div>
 
-      {category.isSystem ? (
-        <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">System</span>
-      ) : (
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => onEdit(category)}
-            disabled={isOptimistic}
-            className="rounded p-1.5 text-gray-500 hover:bg-gray-100 hover:text-primary-600 disabled:opacity-40"
-            aria-label={`Edit ${category.name}`}
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
-          </button>
-          <button
-            type="button"
-            onClick={() => onDelete(category)}
-            disabled={isOptimistic}
-            className="rounded p-1.5 text-gray-500 hover:bg-red-50 hover:text-danger disabled:opacity-40"
-            aria-label={`Delete ${category.name}`}
-          >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-          </button>
-        </div>
-      )}
+      {expanded && !isOptimistic && <SubCategoryPanel category={category} />}
     </div>
   );
 }

--- a/frontend/src/components/categories/SubCategoryForm.tsx
+++ b/frontend/src/components/categories/SubCategoryForm.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import type { SubCategory } from '../../types';
+import IconPicker from './IconPicker';
+import ColorPicker from './ColorPicker';
+
+export interface SubCategoryFormValues {
+  name: string;
+  icon: string | null;
+  color: string | null;
+  monthlyLimit: number | null;
+}
+
+interface SubCategoryFormProps {
+  categoryName: string;
+  /** When provided the form is in edit mode. */
+  subCategory?: SubCategory;
+  isSubmitting?: boolean;
+  onSubmit: (values: SubCategoryFormValues) => void;
+  onCancel: () => void;
+}
+
+function SubCategoryForm({
+  categoryName,
+  subCategory,
+  isSubmitting,
+  onSubmit,
+  onCancel,
+}: SubCategoryFormProps) {
+  const [name, setName] = useState(subCategory?.name ?? '');
+  const [icon, setIcon] = useState<string | null>(subCategory?.icon ?? null);
+  const [color, setColor] = useState<string | null>(subCategory?.color ?? null);
+  const [limit, setLimit] = useState(
+    subCategory?.monthlyLimit != null ? String(subCategory.monthlyLimit) : '',
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const isEdit = Boolean(subCategory);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError('Name is required');
+      return;
+    }
+    let monthlyLimit: number | null = null;
+    if (limit.trim()) {
+      const parsed = Number(limit);
+      if (Number.isNaN(parsed) || parsed <= 0) {
+        setError('Monthly limit must be greater than 0');
+        return;
+      }
+      monthlyLimit = parsed;
+    }
+    onSubmit({ name: trimmed, icon, color, monthlyLimit });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onCancel}
+      role="dialog"
+      aria-modal="true"
+      aria-label={isEdit ? 'Edit sub-category' : 'New sub-category'}
+    >
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit}
+        className="card w-full max-w-md space-y-4"
+      >
+        <div>
+          <h2 className="text-xl font-semibold">
+            {isEdit ? 'Edit sub-category' : 'New sub-category'}
+          </h2>
+          <p className="text-sm text-gray-500">in {categoryName}</p>
+        </div>
+
+        <div>
+          <label htmlFor="sub-name" className="mb-1 block text-sm font-medium text-gray-700">
+            Name
+          </label>
+          <input
+            id="sub-name"
+            className="input"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              if (error) setError(null);
+            }}
+            placeholder="e.g. Groceries"
+            autoFocus
+            maxLength={100}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="sub-limit" className="mb-1 block text-sm font-medium text-gray-700">
+            Monthly limit <span className="text-gray-400">(optional)</span>
+          </label>
+          <input
+            id="sub-limit"
+            className="input"
+            type="number"
+            min="0"
+            step="0.01"
+            value={limit}
+            onChange={(e) => {
+              setLimit(e.target.value);
+              if (error) setError(null);
+            }}
+            placeholder="No limit"
+          />
+        </div>
+
+        <div>
+          <span className="mb-1 block text-sm font-medium text-gray-700">Icon</span>
+          <IconPicker value={icon} onChange={setIcon} />
+        </div>
+
+        <div>
+          <span className="mb-1 block text-sm font-medium text-gray-700">Color</span>
+          <ColorPicker value={color} onChange={setColor} />
+        </div>
+
+        {error && <p className="text-sm text-danger">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" className="btn btn-secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="submit" className="btn btn-primary" disabled={isSubmitting}>
+            {isSubmitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default SubCategoryForm;

--- a/frontend/src/components/categories/SubCategoryPanel.test.tsx
+++ b/frontend/src/components/categories/SubCategoryPanel.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import SubCategoryPanel from './SubCategoryPanel';
+import type { Category, SubCategory } from '../../types';
+
+vi.mock('../../services/api', () => ({
+  subCategoriesApi: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { subCategoriesApi } from '../../services/api';
+
+const mockApi = vi.mocked(subCategoriesApi);
+
+const category: Category = {
+  id: 'cat-1',
+  name: 'Needs',
+  kind: 'EXPENSE',
+  bucket: 'NEEDS',
+  icon: null,
+  color: null,
+  isSystem: false,
+  sortOrder: 0,
+};
+
+function sub(overrides: Partial<SubCategory>): SubCategory {
+  return {
+    id: crypto.randomUUID(),
+    categoryId: category.id,
+    name: 'Sub',
+    icon: '🛒',
+    color: '#2563eb',
+    monthlyLimit: null,
+    isSystem: false,
+    ...overrides,
+  };
+}
+
+function renderPanel() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <SubCategoryPanel category={category} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('SubCategoryPanel', () => {
+  it('shows empty-state guidance when the category has no sub-categories', async () => {
+    mockApi.getAll.mockResolvedValue([]);
+    renderPanel();
+    expect(await screen.findByText('No sub-categories yet')).toBeInTheDocument();
+    // Guidance references the parent category name
+    expect(screen.getByText(/Break/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Add sub-category' })).toBeInTheDocument();
+  });
+
+  it('lists existing sub-categories with their monthly limit', async () => {
+    mockApi.getAll.mockResolvedValue([sub({ name: 'Groceries', monthlyLimit: 600 })]);
+    renderPanel();
+    expect(await screen.findByText('Groceries')).toBeInTheDocument();
+    expect(screen.getByText('Limit 600')).toBeInTheDocument();
+  });
+
+  it('surfaces an error when the sub-categories fail to load', async () => {
+    mockApi.getAll.mockRejectedValue(new Error('kaboom'));
+    renderPanel();
+    expect(await screen.findByText('kaboom')).toBeInTheDocument();
+  });
+
+  it('optimistically adds a sub-category with a monthly limit', async () => {
+    mockApi.getAll.mockResolvedValue([]);
+    let resolveCreate!: (s: SubCategory) => void;
+    mockApi.create.mockReturnValue(new Promise<SubCategory>((res) => { resolveCreate = res; }));
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: '+ Add sub-category' }));
+    await user.type(screen.getByLabelText('Name'), 'Groceries');
+    await user.type(screen.getByLabelText(/Monthly limit/), '600');
+    await user.click(screen.getByRole('option', { name: '🛒' }));
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(await screen.findByText('Groceries')).toBeInTheDocument(); // optimistic row
+    expect(mockApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({ categoryId: 'cat-1', name: 'Groceries', monthlyLimit: 600 }),
+    );
+
+    resolveCreate(sub({ name: 'Groceries', monthlyLimit: 600 }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('validates the name and the monthly limit', async () => {
+    mockApi.getAll.mockResolvedValue([]);
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: '+ Add sub-category' }));
+    // Empty name
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    expect(await screen.findByText('Name is required')).toBeInTheDocument();
+    // Non-positive limit
+    await user.type(screen.getByLabelText('Name'), 'X');
+    await user.type(screen.getByLabelText(/Monthly limit/), '0');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    expect(await screen.findByText('Monthly limit must be greater than 0')).toBeInTheDocument();
+    expect(mockApi.create).not.toHaveBeenCalled();
+  });
+
+  it('rolls back an optimistic add when creation fails', async () => {
+    mockApi.getAll.mockResolvedValue([]);
+    mockApi.create.mockRejectedValue(new Error('nope'));
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: '+ Add sub-category' }));
+    await user.type(screen.getByLabelText('Name'), 'Doomed');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(screen.queryByText('Doomed')).not.toBeInTheDocument());
+  });
+
+  it('edits an existing sub-category', async () => {
+    const existing = sub({ name: 'Groceries' });
+    mockApi.getAll.mockResolvedValue([existing]);
+    mockApi.update.mockResolvedValue({ ...existing, name: 'Food' });
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByLabelText('Edit Groceries'));
+    const nameInput = screen.getByLabelText('Name');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Food');
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() =>
+      expect(mockApi.update).toHaveBeenCalledWith(existing.id, expect.objectContaining({ name: 'Food' })),
+    );
+  });
+
+  it('deletes a sub-category after confirmation', async () => {
+    const existing = sub({ name: 'Groceries' });
+    mockApi.getAll.mockResolvedValue([existing]);
+    mockApi.delete.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByLabelText('Delete Groceries'));
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(mockApi.delete).toHaveBeenCalledWith(existing.id));
+  });
+});

--- a/frontend/src/components/categories/SubCategoryPanel.tsx
+++ b/frontend/src/components/categories/SubCategoryPanel.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import type { Category, SubCategory } from '../../types';
+import {
+  useSubCategories,
+  useCreateSubCategory,
+  useUpdateSubCategory,
+  useDeleteSubCategory,
+} from '../../hooks/useSubCategories';
+import SubCategoryForm, { type SubCategoryFormValues } from './SubCategoryForm';
+
+interface SubCategoryPanelProps {
+  category: Category;
+}
+
+type FormState = { mode: 'create' } | { mode: 'edit'; sub: SubCategory } | null;
+
+/** Expanded content under a category: manage its sub-categories. */
+function SubCategoryPanel({ category }: SubCategoryPanelProps) {
+  const { data: subs, isLoading, isError, error } = useSubCategories(category.id);
+  const createMutation = useCreateSubCategory(category.id);
+  const updateMutation = useUpdateSubCategory(category.id);
+  const deleteMutation = useDeleteSubCategory(category.id);
+
+  const [form, setForm] = useState<FormState>(null);
+  const [confirmDelete, setConfirmDelete] = useState<SubCategory | null>(null);
+
+  const handleSubmit = (values: SubCategoryFormValues) => {
+    const data = { categoryId: category.id, ...values };
+    if (form?.mode === 'edit') {
+      updateMutation.mutate({ id: form.sub.id, data }, { onSuccess: () => setForm(null) });
+    } else {
+      createMutation.mutate(data, { onSuccess: () => setForm(null) });
+    }
+  };
+
+  const confirmDeletion = () => {
+    if (!confirmDelete) return;
+    deleteMutation.mutate(confirmDelete.id);
+    setConfirmDelete(null);
+  };
+
+  const list = subs ?? [];
+
+  return (
+    <div className="border-t border-gray-200 bg-gray-50 px-3 py-3">
+      {isLoading && <p className="py-2 text-center text-sm text-gray-500">Loading sub-categories…</p>}
+
+      {isError && (
+        <p className="py-2 text-center text-sm text-danger">
+          {(error as Error)?.message ?? 'Failed to load sub-categories'}
+        </p>
+      )}
+
+      {!isLoading && !isError && list.length === 0 && (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-white px-4 py-5 text-center">
+          <p className="text-sm font-medium text-gray-700">No sub-categories yet</p>
+          <p className="mx-auto mt-1 max-w-sm text-xs text-gray-500">
+            Break <span className="font-medium">{category.name}</span> into sub-categories (e.g.
+            Groceries, Rent) to track spending in detail and set monthly limits.
+          </p>
+          <button className="btn btn-primary mt-3" onClick={() => setForm({ mode: 'create' })}>
+            + Add sub-category
+          </button>
+        </div>
+      )}
+
+      {!isLoading && !isError && list.length > 0 && (
+        <div className="space-y-1.5">
+          {list.map((sub) => {
+            const isOptimistic = sub.id.startsWith('temp-');
+            return (
+              <div
+                key={sub.id}
+                className={`flex items-center gap-2 rounded-lg bg-white px-3 py-2 ${
+                  isOptimistic ? 'opacity-60' : ''
+                }`}
+              >
+                <span aria-hidden="true">{sub.icon ?? '•'}</span>
+                <span className="min-w-0 flex-1 truncate text-sm text-gray-800">{sub.name}</span>
+                {sub.monthlyLimit != null && (
+                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
+                    Limit {sub.monthlyLimit}
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setForm({ mode: 'edit', sub })}
+                  disabled={isOptimistic}
+                  className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-primary-600 disabled:opacity-40"
+                  aria-label={`Edit ${sub.name}`}
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(sub)}
+                  disabled={isOptimistic}
+                  className="rounded p-1 text-gray-500 hover:bg-red-50 hover:text-danger disabled:opacity-40"
+                  aria-label={`Delete ${sub.name}`}
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </div>
+            );
+          })}
+          <button
+            className="mt-1 text-sm font-medium text-primary-600 hover:text-primary-700"
+            onClick={() => setForm({ mode: 'create' })}
+          >
+            + Add sub-category
+          </button>
+        </div>
+      )}
+
+      {form && (
+        <SubCategoryForm
+          categoryName={category.name}
+          subCategory={form.mode === 'edit' ? form.sub : undefined}
+          isSubmitting={createMutation.isPending || updateMutation.isPending}
+          onSubmit={handleSubmit}
+          onCancel={() => setForm(null)}
+        />
+      )}
+
+      {confirmDelete && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => setConfirmDelete(null)}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="card w-full max-w-sm space-y-4" onClick={(e) => e.stopPropagation()}>
+            <h2 className="text-lg font-semibold">Delete sub-category</h2>
+            <p className="text-sm text-gray-600">
+              Delete <span className="font-medium">{confirmDelete.name}</span>? This can't be undone.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button className="btn btn-secondary" onClick={() => setConfirmDelete(null)}>
+                Cancel
+              </button>
+              <button className="btn btn-danger" onClick={confirmDeletion}>
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SubCategoryPanel;

--- a/frontend/src/hooks/optimisticList.ts
+++ b/frontend/src/hooks/optimisticList.ts
@@ -1,0 +1,32 @@
+import type { QueryClient, QueryKey, UseMutationOptions } from '@tanstack/react-query';
+
+/**
+ * Optimistic-update wiring for a mutation that changes a cached list:
+ * snapshot the list, apply `patch` immediately, roll back on error, and
+ * re-sync from the server once the request settles.
+ *
+ * Shared by the category and sub-category mutation hooks.
+ */
+export function optimisticListUpdate<TItem, TVars>(
+  queryClient: QueryClient,
+  key: QueryKey,
+  patch: (list: TItem[], vars: TVars) => TItem[],
+): Pick<
+  UseMutationOptions<unknown, Error, TVars, { previous?: TItem[] }>,
+  'onMutate' | 'onError' | 'onSettled'
+> {
+  return {
+    onMutate: async (vars) => {
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<TItem[]>(key);
+      queryClient.setQueryData<TItem[]>(key, (old) => patch(old ?? [], vars));
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(key, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: key });
+    },
+  };
+}

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -1,11 +1,7 @@
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-  type UseMutationOptions,
-} from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { categoriesApi } from '../services/api';
 import type { Category, CreateCategoryRequest, UpdateCategoryRequest } from '../types';
+import { optimisticListUpdate } from './optimisticList';
 
 export const CATEGORIES_KEY = ['categories'] as const;
 
@@ -17,38 +13,13 @@ export function useCategories() {
   });
 }
 
-type Ctx = { previous?: Category[] };
-
-/**
- * Shared optimistic-update wiring: snapshot the list, apply `patch`
- * immediately, roll back on error, and re-sync from the server on settle.
- */
-function optimistic<TVars>(
-  queryClient: ReturnType<typeof useQueryClient>,
-  patch: (list: Category[], vars: TVars) => Category[],
-): Pick<UseMutationOptions<unknown, Error, TVars, Ctx>, 'onMutate' | 'onError' | 'onSettled'> {
-  return {
-    onMutate: async (vars) => {
-      await queryClient.cancelQueries({ queryKey: CATEGORIES_KEY });
-      const previous = queryClient.getQueryData<Category[]>(CATEGORIES_KEY);
-      queryClient.setQueryData<Category[]>(CATEGORIES_KEY, (old) => patch(old ?? [], vars));
-      return { previous };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(CATEGORIES_KEY, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: CATEGORIES_KEY });
-    },
-  };
-}
-
 export function useCreateCategory() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: CreateCategoryRequest) => categoriesApi.create(data),
-    ...optimistic<CreateCategoryRequest>(queryClient, (list, data) => {
-      const optimisticCategory: Category = {
+    ...optimisticListUpdate<Category, CreateCategoryRequest>(queryClient, CATEGORIES_KEY, (list, data) => [
+      ...list,
+      {
         id: `temp-${crypto.randomUUID()}`,
         name: data.name,
         kind: data.kind,
@@ -57,9 +28,8 @@ export function useCreateCategory() {
         color: data.color ?? null,
         isSystem: false,
         sortOrder: list.length,
-      };
-      return [...list, optimisticCategory];
-    }),
+      },
+    ]),
   });
 }
 
@@ -68,8 +38,13 @@ export function useUpdateCategory() {
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: UpdateCategoryRequest }) =>
       categoriesApi.update(id, data),
-    ...optimistic<{ id: string; data: UpdateCategoryRequest }>(queryClient, (list, { id, data }) =>
-      list.map((c) => (c.id === id ? { ...c, ...data, icon: data.icon ?? null, color: data.color ?? null } : c)),
+    ...optimisticListUpdate<Category, { id: string; data: UpdateCategoryRequest }>(
+      queryClient,
+      CATEGORIES_KEY,
+      (list, { id, data }) =>
+        list.map((c) =>
+          c.id === id ? { ...c, ...data, icon: data.icon ?? null, color: data.color ?? null } : c,
+        ),
     ),
   });
 }
@@ -78,6 +53,8 @@ export function useDeleteCategory() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => categoriesApi.delete(id),
-    ...optimistic<string>(queryClient, (list, id) => list.filter((c) => c.id !== id)),
+    ...optimisticListUpdate<Category, string>(queryClient, CATEGORIES_KEY, (list, id) =>
+      list.filter((c) => c.id !== id),
+    ),
   });
 }

--- a/frontend/src/hooks/useSubCategories.ts
+++ b/frontend/src/hooks/useSubCategories.ts
@@ -1,0 +1,64 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { subCategoriesApi } from '../services/api';
+import type { CreateSubCategoryRequest, SubCategory, UpdateSubCategoryRequest } from '../types';
+import { optimisticListUpdate } from './optimisticList';
+
+export const subCategoriesKey = (categoryId: string) => ['subcategories', categoryId] as const;
+
+/** Fetches the sub-categories of a single category (lazy — only when mounted). */
+export function useSubCategories(categoryId: string) {
+  return useQuery({
+    queryKey: subCategoriesKey(categoryId),
+    queryFn: () => subCategoriesApi.getAll(categoryId),
+  });
+}
+
+export function useCreateSubCategory(categoryId: string) {
+  const queryClient = useQueryClient();
+  const key = subCategoriesKey(categoryId);
+  return useMutation({
+    mutationFn: (data: CreateSubCategoryRequest) => subCategoriesApi.create(data),
+    ...optimisticListUpdate<SubCategory, CreateSubCategoryRequest>(queryClient, key, (list, data) => [
+      ...list,
+      {
+        id: `temp-${crypto.randomUUID()}`,
+        categoryId: data.categoryId,
+        name: data.name,
+        icon: data.icon ?? null,
+        color: data.color ?? null,
+        monthlyLimit: data.monthlyLimit ?? null,
+        isSystem: false,
+      },
+    ]),
+  });
+}
+
+export function useUpdateSubCategory(categoryId: string) {
+  const queryClient = useQueryClient();
+  const key = subCategoriesKey(categoryId);
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateSubCategoryRequest }) =>
+      subCategoriesApi.update(id, data),
+    ...optimisticListUpdate<SubCategory, { id: string; data: UpdateSubCategoryRequest }>(
+      queryClient,
+      key,
+      (list, { id, data }) =>
+        list.map((s) =>
+          s.id === id
+            ? { ...s, ...data, icon: data.icon ?? null, color: data.color ?? null, monthlyLimit: data.monthlyLimit ?? null }
+            : s,
+        ),
+    ),
+  });
+}
+
+export function useDeleteSubCategory(categoryId: string) {
+  const queryClient = useQueryClient();
+  const key = subCategoriesKey(categoryId);
+  return useMutation({
+    mutationFn: (id: string) => subCategoriesApi.delete(id),
+    ...optimisticListUpdate<SubCategory, string>(queryClient, key, (list, id) =>
+      list.filter((s) => s.id !== id),
+    ),
+  });
+}

--- a/frontend/src/pages/CategoriesPage.test.tsx
+++ b/frontend/src/pages/CategoriesPage.test.tsx
@@ -13,11 +13,18 @@ vi.mock('../services/api', () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+  subCategoriesApi: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
 }));
 
-import { categoriesApi } from '../services/api';
+import { categoriesApi, subCategoriesApi } from '../services/api';
 
 const mockApi = vi.mocked(categoriesApi);
+const mockSubApi = vi.mocked(subCategoriesApi);
 
 function cat(overrides: Partial<Category>): Category {
   return {
@@ -164,5 +171,20 @@ describe('CategoriesPage', () => {
     await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
 
     await waitFor(() => expect(mockApi.delete).toHaveBeenCalledWith(existing.id));
+  });
+
+  it('expands a category to reveal its sub-category manager', async () => {
+    const parent = cat({ name: 'Needs', bucket: 'NEEDS' });
+    mockApi.getAll.mockResolvedValue([parent]);
+    mockSubApi.getAll.mockResolvedValue([]); // no sub-categories yet
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByLabelText('Expand Needs'));
+
+    // Empty-state guidance is shown for a category with no sub-categories
+    expect(await screen.findByText('No sub-categories yet')).toBeInTheDocument();
+    expect(mockSubApi.getAll).toHaveBeenCalledWith(parent.id);
   });
 });


### PR DESCRIPTION
## Summary

Sub-category management (issue #157 · ET-FE-03): **expand a category to create/edit/delete its sub-categories**, with empty-state guidance. **Closes #157.**

Builds on #156 (category screen). The backend `/api/subcategories` API + TS types already existed; this PR is the UI + React Query wiring.

## Acceptance criteria

- ✅ **Expand a category** to manage its sub-categories (chevron toggle on each category row)
- ✅ **Create / edit / delete** sub-categories (icon + color + optional monthly-limit form; delete confirm)
- ✅ **Empty-state guidance** — a category with no sub-categories shows a dashed-border hint explaining what sub-categories are for, with an *Add sub-category* CTA

## What's included

- `CategoryCard` — expand toggle; expanding lazily mounts a `SubCategoryPanel` (per-category query, only fetched when opened).
- `SubCategoryPanel` — list (name + monthly limit), empty-state guidance, add/edit/delete.
- `SubCategoryForm` — modal with name, optional monthly limit (validated `> 0`), icon + color pickers (reused from the category feature).
- `useSubCategories` hook — query + **optimistic** create/update/delete.
- **Refactor:** extracted the optimistic-list mutation wiring into a shared `optimisticList` helper, now used by both `useCategories` and `useSubCategories` (removes duplication).

## Test plan

- [x] `npm run lint` ✅ · `tsc --noEmit` ✅ · `npm run build` ✅
- [x] `npm run test:coverage` ✅ — **18 tests** (8 new SubCategoryPanel + expand test on the page), coverage **Stmts 94% / Branch 88% / Funcs 92% / Lines 96%** (≥ 80% gate)
- New tests cover: empty-state guidance, listing with monthly limit, optimistic add + **rollback on failure**, name + limit validation, edit, delete-with-confirm, load-error, and expanding a category from the page.

## Notes

- Depends on ET-FE-02 (#156, merged) and ET-BE-04 (subcategories API, on `main`).
- Sub-categories are fully editable in P1 (seeds are `isSystem=false`), so no read-only branch was added for them.